### PR TITLE
Fix CI build failure - Update Windows API baseline to 8.1

### DIFF
--- a/Python/PC/pyconfig.h
+++ b/Python/PC/pyconfig.h
@@ -161,9 +161,9 @@ WIN32 is still required for the locale module.
 #endif /* MS_WIN64 */
 
 /* set the version macros for the windows headers */
-/* Python 3.9+ requires Windows 8 or greater */
-#define Py_WINVER 0x0602 /* _WIN32_WINNT_WIN8 */
-#define Py_NTDDI NTDDI_WIN8
+/* Python 3.12+ requires Windows 8.1 or greater */
+#define Py_WINVER 0x0603 /* _WIN32_WINNT_WINBLUE */
+#define Py_NTDDI NTDDI_WINBLUE
 
 /* We only set these values when building Python - we don't want to force
    these values on extensions, as that will affect the prototypes and


### PR DESCRIPTION
## Summary
- Fixes CI build failure by updating Windows API baseline from Windows 8 to Windows 8.1
- Resolves PSS (Process Status API) linker errors in posixmodule.c

## Problem
The CI was failing with unresolved external symbols:
- `PssCaptureSnapshot`
- `PssQuerySnapshot` 
- `PssFreeSnapshot`

These functions are part of the Process Status API introduced in Windows 8.1.

## Solution
Applied the upstream CPython fix that updates the Windows API baseline:
- Updated `Py_WINVER` from `0x0602` (Windows 8) to `0x0603` (Windows 8.1)
- Updated `Py_NTDDI` from `NTDDI_WIN8` to `NTDDI_WINBLUE`

## References
- Original issue: https://github.com/python/cpython/issues/124487
- Upstream fix: https://github.com/miss-islington/cpython/commit/28c8549fc60c23ff22acb758ccbf51c1e30a52c7
- Original author: Steve Dower

## Test plan
- [x] Applied the proven upstream fix with proper attribution
- [ ] Verify CI build passes with this change
- [ ] Confirm no regressions in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)