### PR TITLE
Add weekly CI schedule to catch build failures early

### DIFF
--- a/.github/workflows/Build All.yml
+++ b/.github/workflows/Build All.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Mondays at 6 AM UTC
   workflow_dispatch:
 concurrency:
   group: "${{ github.ref }}"


### PR DESCRIPTION
Added scheduled workflow run every Monday at 6 AM UTC to ensure build issues are discovered proactively, preventing accumulation of breaking changes.

Schedule: '0 6 * * 1' (Mondays at 6 AM UTC)

🤖 Generated with [Claude Code](https://claude.ai/code)