### PR TITLE
Add Release workflow for creating GitHub releases

### DIFF
--- a/.github/workflows/Build All.yml
+++ b/.github/workflows/Build All.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Mondays at 6 AM UTC
   workflow_dispatch:
+  workflow_call:
 concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: true

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Release name (also used as the git tag)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: "./.github/workflows/Build All.yml"
+
+  release:
+    name: Create release
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+
+      - name: Compose release notes
+        run: |
+          set -euo pipefail
+
+          # Pull each version from the source of truth so the notes match the
+          # zips we're about to attach without any manual bookkeeping.
+          PY_VERSION="$(awk '/^#define PY_VERSION[[:space:]]/ {gsub(/"/, "", $3); print $3; exit}' Python/Include/patchlevel.h)"
+          OPENSSL_VERSION="$(sed -n -E 's|.*"OpenSSL ([^ ]+).*|\1|p' openssl/include/openssl/opensslv.h | head -1)"
+          MSVC_TOOLSET="$(sed -n -E 's|.*<PlatformToolset[^>]*>([^<]+)</PlatformToolset>.*|\1|p' MagPython/common.props | head -1)"
+          MACOS_DEPLOY_TARGET="$(sed -n -E 's|^export MACOSX_DEPLOYMENT_TARGET=([0-9.]+).*|\1|p' MagPython/build-macos.sh | head -1)"
+          MANYLINUX_TAG="$(sed -n -E 's|.*quay\.io/pypa/(manylinux[^ ]+).*|\1|p' '.github/workflows/Build All.yml' | head -1)"
+          MACOS_RUNNER="$(sed -n -E "s|^[[:space:]]*runs-on:[[:space:]]*(macos-[0-9]+).*|\1|p" '.github/workflows/Build All.yml' | head -1)"
+
+          for var in PY_VERSION OPENSSL_VERSION MSVC_TOOLSET MACOS_DEPLOY_TARGET MANYLINUX_TAG MACOS_RUNNER; do
+            [ -n "${!var}" ] || { echo "failed to detect $var" >&2; exit 1; }
+          done
+
+          {
+            echo "## Build details"
+            echo
+            echo "### Windows x86"
+            echo "- Python ${PY_VERSION}"
+            echo "- OpenSSL ${OPENSSL_VERSION}"
+            echo "- MSVC Toolset ${MSVC_TOOLSET}"
+            echo
+            echo "### Linux x86_64"
+            echo "- Python ${PY_VERSION}"
+            echo "- OpenSSL ${OPENSSL_VERSION}"
+            echo "- ${MANYLINUX_TAG}"
+            echo
+            echo "### macOS arm64"
+            echo "- Python ${PY_VERSION}"
+            echo "- OpenSSL ${OPENSSL_VERSION}"
+            echo "- ${MACOS_RUNNER} runner, MACOSX_DEPLOYMENT_TARGET=${MACOS_DEPLOY_TARGET}"
+            echo
+          } > body.md
+
+          cat body.md
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NAME: ${{ inputs.name }}
+        run: |
+          set -euo pipefail
+          mapfile -t ASSETS < <(find artifacts -name '*.zip' -type f | sort)
+          [ "${#ASSETS[@]}" -gt 0 ] || { echo "no artifacts found under artifacts/" >&2; exit 1; }
+          # --generate-notes appends GitHub's auto-generated changelog after
+          # the body we wrote (the API pre-pends `body` to the generated notes).
+          gh release create "$NAME" \
+            --title "$NAME" \
+            --target "$GITHUB_SHA" \
+            --notes-file body.md \
+            --generate-notes \
+            "${ASSETS[@]}"


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow for creating releases with build artifacts and automatically generated release notes.

## Key Changes
- **New Release workflow** (`.github/workflows/Release.yml`):
  - Manually triggered via `workflow_dispatch` with a release name input
  - Reuses the existing "Build All" workflow to ensure artifacts are built
  - Automatically extracts version information from source files (Python version, OpenSSL version, MSVC toolset, macOS deployment target, manylinux tag, and macOS runner)
  - Generates structured release notes with build details for Windows, Linux, and macOS platforms
  - Creates a GitHub release with all build artifacts (.zip files) attached
  - Uses GitHub's auto-generated changelog feature for additional context

- **Modified Build All workflow** (`.github/workflows/Build All.yml`):
  - Added `workflow_call` trigger to allow the Release workflow to reuse it as a composite job

## Implementation Details
- Release notes are dynamically composed by parsing configuration files and build scripts, ensuring consistency between documented versions and actual artifacts
- The workflow validates that all required version information is detected before proceeding
- Artifacts are discovered and attached automatically from the build job output
- Release is tagged with the provided name and targets the current commit SHA

https://claude.ai/code/session_01VjsKVjTaeMhS54f96CBucz