### PR TITLE
Make libssl/libcrypto relocatable in macOS + Linux artifacts

### DIFF
--- a/MagPython/build-linux.sh
+++ b/MagPython/build-linux.sh
@@ -78,6 +78,16 @@ ssl_libdir="$BUILD/openssl-out/lib"
 [ -d "$ssl_libdir" ] || ssl_libdir="$BUILD/openssl-out/lib64"
 cp -P "$ssl_libdir"/libcrypto.so* "$STAGE/"
 cp -P "$ssl_libdir"/libssl.so*    "$STAGE/"
+# OpenSSL's link rules embed DT_RUNPATH=<install-prefix>/lib into the
+# shared libs. That path is only valid on the build machine, and while
+# libMagPython.so usually loads libssl/libcrypto first (so the soname
+# lookup hits the already-mapped libs), anything that dlopens libssl
+# directly would resolve libcrypto via that stale RUNPATH and fail.
+# Reset both to $ORIGIN so they find each other as siblings, matching
+# what libMagPython.so already does.
+for f in "$STAGE"/libcrypto.so.1.1 "$STAGE"/libssl.so.1.1; do
+    patchelf --set-rpath '$ORIGIN' "$f"
+done
 
 log "Stripping debug symbols from shared libs"
 # CPython builds with -g -O3 by default; the embedded debug info adds

--- a/MagPython/build-macos.sh
+++ b/MagPython/build-macos.sh
@@ -82,30 +82,47 @@ ssl_libdir="$BUILD/openssl-out/lib"
 cp -P "$ssl_libdir"/libcrypto.*.dylib "$STAGE/"
 cp -P "$ssl_libdir"/libssl.*.dylib    "$STAGE/"
 # Rewrite OpenSSL install names to @rpath so the host application's @rpath
-# controls resolution, and rewrite libMagPython's references to them.
+# controls resolution, and rewrite cross-references between the staged
+# dylibs (libMagPython -> libssl/libcrypto, libssl -> libcrypto) the same way.
 log "Rewriting install names to @rpath"
 for f in "$STAGE"/libcrypto.*.dylib "$STAGE"/libssl.*.dylib; do
     base="$(basename "$f")"
     install_name_tool -id "@rpath/$base" "$f"
 done
-# libMagPython links against libcrypto/libssl with absolute paths from
-# $BUILD/openssl-out; rewrite each to @rpath/<basename>.
-otool -L "$STAGE/libMagPython.dylib" \
-    | awk -v root="$BUILD/openssl-out" '$1 ~ root {print $1}' \
-    | while read -r path; do
-        base="$(basename "$path")"
-        install_name_tool -change "$path" "@rpath/$base" "$STAGE/libMagPython.dylib"
-    done
-# Drop any absolute LC_RPATH entries that point at the build's openssl-out
-# (added by --with-openssl-rpath=auto). @loader_path was already added via
-# LDFLAGS_NODIST, so removing the absolutes makes the artifact relocatable.
-otool -l "$STAGE/libMagPython.dylib" \
-    | awk -v root="$BUILD/openssl-out" '
-        /^ +cmd LC_RPATH/   { in_rpath=1; next }
-        in_rpath && /path / { if (index($2, root) == 1) print $2; in_rpath=0 }
-    ' | while read -r rpath; do
-        install_name_tool -delete_rpath "$rpath" "$STAGE/libMagPython.dylib"
-    done
+# libMagPython links against libcrypto/libssl, and libssl links against
+# libcrypto, all with absolute paths from $BUILD/openssl-out. Without
+# rewriting libssl's reference too, a host running the artifact directly
+# (no DYLD_FALLBACK_LIBRARY_PATH) hits a dyld error pointing at the
+# runner's build dir. Apply the same rewrite + rpath cleanup uniformly.
+for f in "$STAGE/libMagPython.dylib" "$STAGE"/libcrypto.*.dylib "$STAGE"/libssl.*.dylib; do
+    otool -L "$f" \
+        | awk -v root="$BUILD/openssl-out" '$1 ~ root {print $1}' \
+        | while read -r path; do
+            base="$(basename "$path")"
+            install_name_tool -change "$path" "@rpath/$base" "$f"
+        done
+    # Drop any absolute LC_RPATH entries that point at the build's
+    # openssl-out (added by --with-openssl-rpath=auto and by OpenSSL's
+    # own link rules) so the artifact is relocatable.
+    otool -l "$f" \
+        | awk -v root="$BUILD/openssl-out" '
+            /^ +cmd LC_RPATH/   { in_rpath=1; next }
+            in_rpath && /path / { if (index($2, root) == 1) print $2; in_rpath=0 }
+        ' | while read -r rpath; do
+            install_name_tool -delete_rpath "$rpath" "$f"
+        done
+done
+# Add @loader_path to LC_RPATH on libssl/libcrypto so the @rpath/libcrypto
+# reference inside libssl resolves to its sibling regardless of what
+# rpaths the loading binary supplies. libMagPython already has this via
+# LDFLAGS_NODIST in configure_libmagpython.
+for f in "$STAGE"/libcrypto.*.dylib "$STAGE"/libssl.*.dylib; do
+    if ! otool -l "$f" \
+            | awk '/^ +cmd LC_RPATH/{r=1;next} r && /path /{print $2;r=0}' \
+            | grep -qx "@loader_path"; then
+        install_name_tool -add_rpath "@loader_path" "$f"
+    fi
+done
 
 log "Stripping debug symbols from shared libs"
 # CPython builds with -g -O3 by default; the embedded debug info adds
@@ -120,8 +137,15 @@ stage_headers_and_stdlib "$BUILD/main"
 run_smoke_test '@loader_path'
 
 # Sanity: only @rpath/* and system libs should remain in the LC_LOAD_DYLIB
-# entries of libMagPython.
+# entries of any shipped dylib. libssl in particular must not retain the
+# absolute libcrypto reference baked in at OpenSSL build time.
 log "otool sanity"
-otool -L "$STAGE/libMagPython.dylib"
+for f in "$STAGE"/libMagPython.dylib "$STAGE"/libcrypto.*.dylib "$STAGE"/libssl.*.dylib; do
+    otool -L "$f"
+    if otool -L "$f" | awk -v root="$BUILD/openssl-out" 'NR>1 && $1 ~ root {found=1} END {exit !found}'; then
+        echo "ERROR: $f still references $BUILD/openssl-out" >&2
+        exit 1
+    fi
+done
 
 zip_artifact macos-arm64


### PR DESCRIPTION
## Summary

Host-app team flagged that on macOS-arm64, `libssl.1.1.dylib` in our artifact still has its `LC_LOAD_DYLIB` for libcrypto baked as the absolute build path
`/Users/runner/work/magnolia-python/magnolia-python/build-out/openssl-out/lib/libcrypto.1.1.dylib`. The Magnolia Makefile masks this with `DYLD_FALLBACK_LIBRARY_PATH`, but anyone running the produced host app directly hits a dyld error referencing a path that doesn't exist on their machine.

- **macOS** (`build-macos.sh`): we already rewrite `libMagPython.dylib`'s libcrypto/libssl references to `@rpath/...`, but never did the same pass for libssl itself. Generalise the existing rewrite + RPATH cleanup loop to cover libMagPython, libssl, and libcrypto uniformly. Add `@loader_path` to `LC_RPATH` on the OpenSSL dylibs so the new `@rpath/libcrypto` reference inside libssl resolves to its sibling regardless of what rpaths the loading binary supplies. Extend the otool sanity sweep to fail the build if any shipped dylib still mentions `$BUILD/openssl-out`.
- **Linux** (`build-linux.sh`): different mechanism but parallel hygiene gap. ELF `DT_NEEDED` is by soname, so there's no absolute-path version of the bug — but OpenSSL's link rules embed `DT_RUNPATH=<install-prefix>/lib` into both `.so`s. Today libMagPython loads libssl + libcrypto first so the libcrypto soname lookup hits the already-mapped lib and the stale path is dormant; anything that `dlopen`s libssl on its own would resolve libcrypto via the build-machine path and fail. `patchelf --set-rpath '$ORIGIN'` on both, matching what we already do for `libMagPython.so`.

## Test plan

- [ ] CI macOS-arm64 build: confirm the new otool sanity loop reports only `@rpath/*` and system libs (`/usr/lib/...`, `/System/...`) for `libMagPython.dylib`, `libcrypto.1.1.dylib`, `libssl.1.1.dylib` — no `$BUILD/openssl-out` paths anywhere
- [ ] CI macOS-arm64: `run_smoke_test '@loader_path'` still passes after the additional `install_name_tool -change` and `-add_rpath` calls
- [ ] On a fresh macOS-arm64 box (no `DYLD_FALLBACK_LIBRARY_PATH`), unzip the artifact and `otool -L libssl.1.1.dylib` — libcrypto entry should now read `@rpath/libcrypto.1.1.dylib`
- [ ] CI Linux build: `readelf -d libssl.so.1.1 libcrypto.so.1.1 | grep -E 'RUNPATH|RPATH'` shows `$ORIGIN` only, no `openssl-out/lib`
- [ ] CI Linux: smoke test still passes (RUNPATH change shouldn't affect the existing libMagPython load path)

https://claude.ai/code/session_01P4boRVJKRFz98f3cYPeKXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4boRVJKRFz98f3cYPeKXE)_