### PR TITLE
Document Windows 8.1 deployment target and API requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Notable differences from a stock CPython Windows build:
   iphlpapi.lib;Rpcrt4.lib`.
 - Targets `x86` only (the `Platform` defaults to `Win32` in
   `MagPython/common.props`); `PlatformToolset` is `v142` (VS 2019).
+  Deployment target is Windows 8.1 — `Py_WINVER` is `0x0603` in
+  `Python/PC/pyconfig.h.in`, so `MagPython.dll` statically imports
+  Windows 8.1 APIs (e.g. PSS) and is expected to load on Windows 8.1
+  and newer with the VC++ 2015-2022 redistributable installed.
 - Frozen modules and `Python/deepfreeze/deepfreeze.c` are regenerated as part
   of the build (see below) and are gitignored.
 


### PR DESCRIPTION
## Summary
Updated README.md to clarify the Windows deployment target and static API dependencies for MagPython builds.

## Changes
- Added documentation specifying Windows 8.1 as the deployment target
- Documented that `Py_WINVER` is set to `0x0603` in `Python/PC/pyconfig.h.in`
- Clarified that `MagPython.dll` statically imports Windows 8.1 APIs (e.g., PSS)
- Noted the runtime requirement for VC++ 2015-2022 redistributable on Windows 8.1 and newer systems

## Details
This documentation update provides important context for developers and users about the minimum Windows version supported and the specific API level targeted by the build. The information helps clarify compatibility expectations and runtime dependencies.

https://claude.ai/code/session_01EuXwKne6W4j5QvvGWfSc2n