### PR TITLE
Update Windows build runner from windows-2022 to windows-2025

### DIFF
--- a/.github/workflows/Build All.yml
+++ b/.github/workflows/Build All.yml
@@ -23,7 +23,12 @@ jobs:
       matrix:
         include:
           - platform: windows-x86
-            runs-on: windows-2022
+            # Explicit label, not windows-latest: the build needs the
+            # v142 toolset component (see README), which is only
+            # guaranteed to be present on the explicitly-labelled
+            # images. Don't bump past windows-2025 without confirming
+            # the v142 component is still installed on the new image.
+            runs-on: windows-2025
             artifact-path: MagPython-windows-x86.zip
           - platform: linux-x86_64
             runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ shared library. Three platforms are produced from the same source tree:
 
 | Platform        | Runner          | Main library             |
 | ---             | ---             | ---                      |
-| Windows x86     | `windows-2022`  | `MagPython.dll`          |
+| Windows x86     | `windows-2025`  | `MagPython.dll`          |
 | Linux x86_64    | manylinux_2_28  | `libMagPython.so`        |
 | macOS arm64     | `macos-14`      | `libMagPython.dylib`     |
 
@@ -547,7 +547,7 @@ always reported regardless — `<ClInclude>` ones rot the IDE view,
 `.github/workflows/Build All.yml` is a single matrix-based workflow that
 fans out across three platforms:
 
-- `windows-2022` (x86, MSVC) — runs the existing `msbuild MagPython.metaproj`
+- `windows-2025` (x86, MSVC) — runs the existing `msbuild MagPython.metaproj`
   flow.
 - `ubuntu-22.04` inside the `quay.io/pypa/manylinux_2_28_x86_64` container
   — runs `MagPython/build-linux.sh`.


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow and documentation to use `windows-2025` instead of `windows-2022` for the Windows x86 build platform.

## Changes
- Updated `.github/workflows/Build All.yml` to run Windows x86 builds on `windows-2025` instead of `windows-2022`
- Added detailed comments explaining the requirement for the v142 toolset component and the need to use explicitly-labeled images rather than `windows-latest`
- Updated `README.md` to reflect the new runner image in both the platform table and the workflow documentation section

## Implementation Details
The change includes a cautionary note in the workflow file indicating that future updates should confirm the v142 MSVC toolset component remains available on newer Windows images before bumping the version further. This ensures the build continues to work correctly with the required compiler toolset.

https://claude.ai/code/session_01EuXwKne6W4j5QvvGWfSc2n