### PR TITLE
Ship OpenSSL SDK in artifacts; smoke-test it directly

### DIFF
--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -251,6 +251,12 @@ stage_headers_and_stdlib() {
 
 # Build and run the smoke test (MagPython/test.c) against the staged tree.
 # $1: rpath token ('$ORIGIN' on Linux, '@loader_path' on macOS).
+#
+# The cc invocation deliberately uses ONLY $STAGE for both -I and -L: the
+# build dir's openssl-out/ and CPython build outputs are off the search path,
+# so a missing header or unversioned shared-lib symlink (e.g. libssl.dylib ->
+# libssl.<ver>.dylib) in the artifact is a hard failure here rather than a
+# silent fallback to the build tree.
 run_smoke_test() {
     local rpath_token="$1"
     log "Building smoke test"
@@ -258,7 +264,7 @@ run_smoke_test() {
         -I"$STAGE/include" \
         -L"$STAGE" \
         "-Wl,-rpath,${rpath_token}" \
-        -lMagPython \
+        -lMagPython -lssl -lcrypto \
         -o "$STAGE/MagPython_test"
     log "Running smoke test"
     # No PYTHONPATH/PYTHONHOME needed: stage_headers_and_stdlib added a

--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -212,6 +212,25 @@ flip_modules_to_static() {
     (cd "$build_dir" && make -j1 Makefile Modules/config.c)
 }
 
+# Stage OpenSSL development files (public + internal headers) into the artifact
+# tree, mirroring the Windows artifact shape produced by openssl.vcxproj's
+# CopyArtifacts target. The public include/openssl/ tree comes from the
+# install_sw output (includes Configure-generated headers like opensslconf.h);
+# the internal include/crypto/ tree isn't installed by install_sw, so we copy
+# .h files straight from the post-Configure source tree (which is where
+# Configure materialises bn_conf.h / dso_conf.h from their .h.in templates).
+# Linux/macOS link against libssl/libcrypto via the unversioned symlinks
+# install_sw creates next to the real shared libs, so no platform-specific
+# import library is needed here — that part is handled by the per-platform
+# library copy step.
+stage_openssl_headers() {
+    log "Staging OpenSSL headers"
+    mkdir -p "$STAGE/include/openssl" "$STAGE/include/crypto"
+    cp -R "$BUILD/openssl-out/include/openssl/." "$STAGE/include/openssl/"
+    find "$REPO/openssl/include/crypto" -maxdepth 1 -type f -iname '*.h' \
+        -exec cp {} "$STAGE/include/crypto/" \;
+}
+
 # Stage headers and pure-Python stdlib into the artifact tree.
 # On Unix the stdlib lives under `lib/python$PY_X_Y/` so Python's path
 # discovery (which looks for `lib/pythonX.Y/os.py` walking up from the

--- a/MagPython/build-linux.sh
+++ b/MagPython/build-linux.sh
@@ -99,6 +99,7 @@ for f in "$STAGE"/libMagPython.so "$STAGE"/libcrypto.so.1.1 "$STAGE"/libssl.so.1
 done
 
 stage_headers_and_stdlib "$BUILD/main"
+stage_openssl_headers
 run_smoke_test '$ORIGIN'
 
 # Sanity: ensure no surprise glibc-only-recent symbols. manylinux2014 ships

--- a/MagPython/build-macos.sh
+++ b/MagPython/build-macos.sh
@@ -81,6 +81,14 @@ log "Copying OpenSSL dylibs"
 ssl_libdir="$BUILD/openssl-out/lib"
 cp -P "$ssl_libdir"/libcrypto.*.dylib "$STAGE/"
 cp -P "$ssl_libdir"/libssl.*.dylib    "$STAGE/"
+# install_sw also creates unversioned symlinks (libcrypto.dylib ->
+# libcrypto.<ver>.dylib, same for libssl). The libcrypto.*.dylib glob above
+# requires at least one char between the dots, so it doesn't pick those up.
+# Copy them with -P so consumers can link against -lcrypto / -lssl, mirroring
+# the libssl.so / libcrypto.so symlinks already shipped on Linux and the
+# libssl.lib / libcrypto.lib import libs shipped on Windows.
+cp -P "$ssl_libdir"/libcrypto.dylib "$STAGE/"
+cp -P "$ssl_libdir"/libssl.dylib    "$STAGE/"
 # Rewrite OpenSSL install names to @rpath so the host application's @rpath
 # controls resolution, and rewrite cross-references between the staged
 # dylibs (libMagPython -> libssl/libcrypto, libssl -> libcrypto) the same way.
@@ -134,6 +142,7 @@ for f in "$STAGE"/libMagPython.dylib "$STAGE"/libcrypto.*.dylib "$STAGE"/libssl.
 done
 
 stage_headers_and_stdlib "$BUILD/main"
+stage_openssl_headers
 run_smoke_test '@loader_path'
 
 # Sanity: only @rpath/* and system libs should remain in the LC_LOAD_DYLIB

--- a/MagPython/test.c
+++ b/MagPython/test.c
@@ -1,5 +1,9 @@
 ﻿#include <Python/Python.h>
+#include <openssl/opensslv.h>
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
 #include <stdio.h>
+#include <string.h>
 
 static int try_import(const char *module) {
     PyObject *m = PyImport_ImportModule(module);
@@ -10,6 +14,30 @@ static int try_import(const char *module) {
     }
     printf("  %s OK\n", module);
     Py_DECREF(m);
+    return 0;
+}
+
+// Exercise OpenSSL directly (not just through Python's _ssl) so the artifact
+// is validated as a usable OpenSSL SDK: the headers must be present at
+// compile time, the libcrypto/libssl import lib (Windows) or unversioned
+// symlink (Linux/macOS) must be present at link time, and the shared lib
+// must resolve at runtime via the artifact's rpath. Also compares the
+// header's compile-time version against libcrypto's runtime version to
+// catch a header/lib mismatch.
+static int exercise_openssl(void) {
+    const char *header_ver = OPENSSL_VERSION_TEXT;
+    const char *runtime_ver = OpenSSL_version(OPENSSL_VERSION);
+    printf("  OpenSSL header:  %s\n", header_ver);
+    printf("  OpenSSL runtime: %s\n", runtime_ver);
+    if (strcmp(header_ver, runtime_ver) != 0) {
+        fprintf(stderr, "  OpenSSL header/runtime version mismatch\n");
+        return -1;
+    }
+    if (OPENSSL_init_ssl(0, NULL) != 1) {
+        fprintf(stderr, "  OPENSSL_init_ssl FAILED\n");
+        return -1;
+    }
+    printf("  OpenSSL init OK\n");
     return 0;
 }
 
@@ -48,6 +76,9 @@ int main(int argc, char *argv[]) {
     }
 
     int failures = 0;
+    printf("Exercising OpenSSL:\n");
+    failures += exercise_openssl() != 0;
+
     printf("Importing modules:\n");
     failures += try_import("decimal") != 0;
     failures += try_import("ssl") != 0;

--- a/MagPython/test.vcxproj
+++ b/MagPython/test.vcxproj
@@ -53,6 +53,13 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(DepsDir)</AdditionalLibraryDirectories>
+      <!-- libssl.lib / libcrypto.lib are MagPython's responsibility for its
+           own static link, but test.c also calls OpenSSL directly to verify
+           the artifact ships a usable OpenSSL SDK (headers + import libs +
+           DLLs). MagPython.lib is auto-linked via the #pragma in the
+           generated pyconfig.h; OpenSSL has no such pragma, so list its
+           import libs explicitly. -->
+      <AdditionalDependencies>libssl.lib;libcrypto.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

The Windows artifact already shipped a usable OpenSSL SDK (headers under
`include/openssl/` + `include/crypto/`, `libssl.lib`/`libcrypto.lib` import
libs, the DLLs, and `applink.c`), set up by `openssl.vcxproj`'s
`CopyArtifacts` target. The Linux and macOS artifacts shipped only the
shared libs, so a downstream consumer couldn't `#include <openssl/...>` or
link against `-lssl`/`-lcrypto` without a separate OpenSSL dev install.

Two changes:

1. **Stage OpenSSL headers + link symlinks on Linux and macOS**
   - New `stage_openssl_headers` helper in `build-common.sh` copies the
     public `include/openssl/` tree from `make install_sw`'s output (so the
     Configure-generated headers like `opensslconf.h` come along) and the
     internal `include/crypto/` `.h` files from the in-tree source
     (install_sw doesn't install those).
   - On macOS, also copy the unversioned `libssl.dylib` /
     `libcrypto.dylib` symlinks. The existing `libcrypto.*.dylib` glob
     requires a non-empty middle segment, so it skipped them, leaving
     `-lssl`/`-lcrypto` unresolvable. Linux already shipped the
     `libssl.so` / `libcrypto.so` symlinks via the `libcrypto.so*` glob.

2. **Exercise OpenSSL in the smoke test so a broken artifact fails hard**
   - `test.c` now `#include`s `<openssl/...>` and calls `OpenSSL_version()`
     + `OPENSSL_init_ssl()` directly, and compares the header's
     compile-time version against libcrypto's runtime version. Previously
     the test only used OpenSSL transitively via Python's `_ssl`, so a
     missing header or import lib could pass as long as `libMagPython`
     itself loaded.
   - `build-common.sh`'s smoke-test cc gains `-lssl -lcrypto`;
     `test.vcxproj` adds `libssl.lib;libcrypto.lib` to
     `AdditionalDependencies`. The cc command keeps `-I`/`-L` limited to
     `$STAGE` so a missing artifact piece can't be silently masked by a
     fallback to the build tree.

## Test plan

- [ ] CI green on `windows-x86`, `linux-x86_64`, and `macos-arm64`
- [ ] `MagPython-<platform>.zip` contains `include/openssl/*.h` and
      `include/crypto/*.h` on all three platforms
- [ ] macOS zip contains both `libssl.dylib` (symlink) and the versioned
      `libssl.<ver>.dylib` (and same for libcrypto)
- [ ] Smoke test prints matching `OpenSSL header:` and `OpenSSL runtime:`
      lines on every platform

https://claude.ai/code/session_01Duf3oYGxCBYo97uJzuWMC4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Duf3oYGxCBYo97uJzuWMC4)_