### PR TITLE
Add dumpbin report generation for shipped DLLs

### DIFF
--- a/MagPython/MagPython.vcxproj
+++ b/MagPython/MagPython.vcxproj
@@ -712,4 +712,20 @@
     <Copy SourceFiles="@(IncludeFile)" DestinationFolder="$(OutDir)\include\Python\%(RecursiveDir)" />
     <Copy SourceFiles="@(PythonFiles)" DestinationFolder="$(OutDir)\lib\%(RecursiveDir)" />
   </Target>
+
+  <!-- Capture dumpbin output for the shipped DLLs so toolchain/SDK changes
+       (e.g. runner image, MSVC toolset) can be diffed against a baseline.
+       See PR #29 for the validation checklist that motivated this. -->
+  <Target Name="DumpBinReport" AfterTargets="Build">
+    <ItemGroup>
+      <DumpBinTarget Include="$(OutDir)MagPython.dll" />
+      <DumpBinTarget Include="$(OutDir)libcrypto-1_1.dll" />
+      <DumpBinTarget Include="$(OutDir)libssl-1_1.dll" />
+    </ItemGroup>
+    <MakeDir Directories="$(OutDir)dumpbin" />
+    <Exec Command="dumpbin /headers &quot;%(DumpBinTarget.Identity)&quot; &gt; &quot;$(OutDir)dumpbin\%(DumpBinTarget.Filename)%(DumpBinTarget.Extension).headers.txt&quot;" />
+    <Exec Command="dumpbin /imports &quot;%(DumpBinTarget.Identity)&quot; &gt; &quot;$(OutDir)dumpbin\%(DumpBinTarget.Filename)%(DumpBinTarget.Extension).imports.txt&quot;" />
+    <Exec Command="dumpbin /exports &quot;%(DumpBinTarget.Identity)&quot; &gt; &quot;$(OutDir)dumpbin\%(DumpBinTarget.Filename)%(DumpBinTarget.Extension).exports.txt&quot;" />
+    <Exec Command="dumpbin /loadconfig &quot;%(DumpBinTarget.Identity)&quot; &gt; &quot;$(OutDir)dumpbin\%(DumpBinTarget.Filename)%(DumpBinTarget.Extension).loadconfig.txt&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
This change adds a new MSBuild target that automatically generates dumpbin analysis reports for the shipped DLLs after each build. This enables tracking of toolchain and SDK changes by comparing binary characteristics against a baseline.

## Key Changes
- Added `DumpBinReport` target that runs after the `Build` target
- Generates dumpbin output for three DLLs: `MagPython.dll`, `libcrypto-1_1.dll`, and `libssl-1_1.dll`
- Creates four analysis reports per DLL:
  - `/headers` - PE header information
  - `/imports` - Imported dependencies
  - `/exports` - Exported symbols
  - `/loadconfig` - Load configuration details
- Reports are written to `$(OutDir)dumpbin/` directory with descriptive filenames

## Implementation Details
- Uses MSBuild `ItemGroup` to define target DLLs
- Leverages MSBuild metadata (`%(RecursiveDir)`, `%(Filename)`, `%(Extension)`) for flexible file naming
- Creates output directory automatically via `MakeDir` task
- Executes dumpbin commands via `Exec` task with proper output redirection
- Motivated by validation checklist in PR #29 to detect unintended binary changes from toolchain updates

https://claude.ai/code/session_016piqgBPVs8Us55zeLV56H9