### PR TITLE
Remove auditwheel check and clarify zip installation comment

### DIFF
--- a/MagPython/build-linux.sh
+++ b/MagPython/build-linux.sh
@@ -26,8 +26,8 @@ source "$SCRIPT_DIR/build-common.sh"
 HOST_PYTHON="/opt/python/cp313-cp313/bin/python3"
 [ -x "$HOST_PYTHON" ] || HOST_PYTHON="$(command -v python3)"
 
-# manylinux_2_28 ships patchelf (auditwheel needs it) but not zip; install
-# zip on demand. Keep the install line idempotent so re-runs are cheap.
+# manylinux_2_28 doesn't ship zip; install it on demand. Keep the install line
+# idempotent so re-runs are cheap.
 if ! command -v zip >/dev/null; then
     if command -v dnf >/dev/null; then
         dnf install -y zip
@@ -101,12 +101,5 @@ done
 stage_headers_and_stdlib "$BUILD/main"
 stage_openssl_headers
 run_smoke_test '$ORIGIN'
-
-# Sanity: ensure no surprise glibc-only-recent symbols. manylinux2014 ships
-# auditwheel; skip this check gracefully if it isn't available locally.
-if command -v auditwheel >/dev/null; then
-    log "auditwheel show (informational)"
-    auditwheel show "$STAGE/libMagPython.so" || true
-fi
 
 zip_artifact linux-x86_64


### PR DESCRIPTION
## Summary
This PR removes the auditwheel symbol checking step from the Linux build process and updates a comment to be more concise about the zip installation requirement.

## Key Changes
- **Removed auditwheel check**: Deleted the conditional block that ran `auditwheel show` on the built libMagPython.so. This informational check is no longer needed in the build pipeline.
- **Updated comment**: Simplified the comment about zip installation to remove the mention of patchelf (which manylinux_2_28 does ship) and focus only on the zip requirement.

## Details
The auditwheel check was an informational step that verified no surprise glibc-only-recent symbols were present in the binary. By removing this, the build process becomes simpler and faster, while the actual artifact creation (zip_artifact) remains unchanged.

https://claude.ai/code/session_0187B7Ji7dSqt2FVspx4gqN2