### PR TITLE
Update Windows build documentation for VS 2026 compatibility

### DIFF
--- a/.github/workflows/Build All.yml
+++ b/.github/workflows/Build All.yml
@@ -26,8 +26,12 @@ jobs:
             # Explicit label, not windows-latest: the build needs the
             # v142 toolset component (see README), which is only
             # guaranteed to be present on the explicitly-labelled
-            # images. Don't bump past windows-2025 without confirming
-            # the v142 component is still installed on the new image.
+            # images. As of 2026-05-12 GitHub redirects this label to
+            # the windows-2025-vs2026 image (VS 2026 replacing VS 2022);
+            # v142 is preserved on that image via the
+            # Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64
+            # component. Don't bump past windows-2025 without confirming
+            # v142 is still present on the new image.
             runs-on: windows-2025
           - platform: linux-x86_64
             runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow documentation to clarify the current state of the Windows build environment and its compatibility with Visual Studio toolsets.

## Key Changes
- Updated comments in the Windows build job to reflect that as of 2026-05-12, the `windows-2025` label now redirects to the `windows-2025-vs2026` image
- Documented that Visual Studio 2026 replaces VS 2022 on the new image
- Added specific reference to the `Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64` component that preserves v142 toolset support on the new image
- Clarified the guidance for future image updates to verify v142 presence rather than warning against bumping past windows-2025

## Notable Details
This is a documentation-only change that helps maintainers understand the current CI environment configuration and provides clear guidance for future updates when GitHub Actions images are refreshed.

https://claude.ai/code/session_014xuotVvruxQ84FL6qbXg7t