### PR TITLE
Renovate config + libffi drift CI workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^MagPython/openssl-version$"],
+      "matchStrings": ["^(?<currentValue>.+?)\\s*$"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "openssl",
+      "packageNameTemplate": "openssl/openssl",
+      "extractVersionTemplate": "^openssl-(?<version>3\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^MagPython/zlib-version$"],
+      "matchStrings": ["^(?<currentValue>.+?)\\s*$"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "zlib",
+      "packageNameTemplate": "madler/zlib",
+      "extractVersionTemplate": "^v(?<version>1\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^MagPython/libffi-version$"],
+      "matchStrings": ["^(?<currentValue>.+?)\\s*$"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "libffi",
+      "packageNameTemplate": "libffi/libffi",
+      "extractVersionTemplate": "^v(?<version>3\\.\\d+\\.\\d+)$"
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "MagPython/update-{{depName}}.sh {{newVersion}}"
+    ],
+    "fileFilters": [
+      "MagPython/openssl-version",
+      "MagPython/openssl-sha256",
+      "MagPython/zlib-version",
+      "MagPython/zlib-sha256",
+      "MagPython/libffi-version",
+      "MagPython/libffi-sha256",
+      "MagPython/libffi-msvc-include/ffi.h"
+    ],
+    "executionMode": "update"
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["openssl", "zlib", "libffi"],
+      "commitMessageTopic": "{{depName}} pin",
+      "commitMessageAction": "Bump",
+      "groupName": null
+    }
+  ]
+}

--- a/.github/workflows/Verify libffi drift.yml
+++ b/.github/workflows/Verify libffi drift.yml
@@ -1,0 +1,51 @@
+name: Verify libffi drift
+
+# Runs on PRs that touch libffi-related files. Catches the case where a
+# Renovate-driven (or manual) libffi version bump would break the
+# Windows build because upstream renamed/removed a file that
+# LibFFI.vcxproj's per-file <ClCompile> / <CustomBuild> / <ClInclude>
+# list still references.
+#
+# The build itself surfaces the same drift later as a cl.exe C1083
+# 'cannot open source file' error during the LibFFI.vcxproj step; this
+# workflow just makes it visible at PR-review time on a Linux runner
+# (~30s wall-clock) instead of waiting for a 5+ minute Windows job.
+
+on:
+  pull_request:
+    paths:
+      - 'MagPython/libffi-version'
+      - 'MagPython/libffi-sha256'
+      - 'MagPython/LibFFI.vcxproj'
+  # Allow manual trigger for paranoid checks (e.g. validating that
+  # main currently passes after an unrelated merge).
+  workflow_dispatch:
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache libffi download
+        uses: actions/cache@v4
+        with:
+          path: MagPython/libffi
+          key: deps-libffi-drift-${{ hashFiles('MagPython/libffi-version', 'MagPython/libffi-sha256') }}
+
+      - name: Populate libffi cache
+        # Source build-common.sh in a subshell so its `set -x` doesn't
+        # leak into subsequent steps. The `set +x` after sourcing
+        # silences the trace for the actual setup_libffi run; the
+        # 2>/dev/null on the disable-trace command itself is the
+        # standard idiom to suppress the trace of `set +x` itself.
+        run: |
+          bash -c '
+            . MagPython/build-common.sh
+            { set +x; } 2>/dev/null
+            setup_libffi
+          '
+
+      - name: Check LibFFI.vcxproj refs against the libffi tree
+        run: MagPython/check-libffi-drift.sh

--- a/MagPython/check-libffi-drift.sh
+++ b/MagPython/check-libffi-drift.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Verify that every .c/.S/.h file referenced by MagPython/LibFFI.vcxproj
+# exists in the build-time-downloaded libffi tree (or in the project-local
+# MagPython/libffi-msvc-include/, for the pregenerated MSVC headers).
+#
+# Catches the case where upstream renamed/removed a file that
+# LibFFI.vcxproj still references — without this check, the drift only
+# surfaces at the next Windows build when cl.exe / ml.exe fails with a
+# C1083 ('cannot open source file') error.
+#
+# The corresponding "did upstream add NEW files we should compile" check
+# is harder to automate without baseline drift bookkeeping (the pre-
+# devendor MagPython/update-libffi.sh did this, but the baseline tree
+# is gone now). For the libffi 3.x line the per-file <ClCompile> list is
+# stable, so the GONE-only check is the practical compromise.
+#
+# Run by .github/workflows/Verify libffi drift.yml on any PR that
+# touches MagPython/{libffi-version,libffi-sha256,LibFFI.vcxproj}. The
+# workflow populates the cache (via setup_libffi) before running this.
+#
+# Compatible with bash 3.2 (the default on macOS).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERSION="$(tr -d '[:space:]' < "$SCRIPT_DIR/libffi-version")"
+SOURCE_DIR="$SCRIPT_DIR/libffi/libffi-$VERSION"
+PREGEN_DIR="$SCRIPT_DIR/libffi-msvc-include"
+VCXPROJ="$SCRIPT_DIR/LibFFI.vcxproj"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "ERROR: libffi cache not populated at $SOURCE_DIR" >&2
+    echo "       Run \`. MagPython/build-common.sh; setup_libffi\` first." >&2
+    exit 1
+fi
+if [ ! -d "$PREGEN_DIR" ]; then
+    echo "ERROR: project-local pregenerated header dir missing: $PREGEN_DIR" >&2
+    exit 1
+fi
+[ -f "$VCXPROJ" ] || { echo "ERROR: missing $VCXPROJ" >&2; exit 1; }
+
+# Pull the path attribute from each Include="..." entry that points
+# into the build tree (variable-prefixed and ending in .c/.S/.h). The
+# vcxproj uses Windows backslashes; the loop below converts them.
+missing=0
+total=0
+while IFS= read -r path; do
+    total=$((total + 1))
+    case "$path" in
+        '$(LibFFITargetPregeneratedIncludeDir)\\'*)
+            ref="$PREGEN_DIR/${path#'$(LibFFITargetPregeneratedIncludeDir)\\'}"
+            ;;
+        '$(LibFFITargetSourceDir)\\'*)
+            ref="$SOURCE_DIR/src/x86/${path#'$(LibFFITargetSourceDir)\\'}"
+            ;;
+        '$(LibFFISourceDir)\\'*)
+            ref="$SOURCE_DIR/src/${path#'$(LibFFISourceDir)\\'}"
+            ;;
+        '$(SourceDir)\\'*)
+            ref="$SOURCE_DIR/${path#'$(SourceDir)\\'}"
+            ;;
+        *)
+            # Skip ClCompile/ClInclude items that don't point into our
+            # source-variable namespace (none expected today, but leave
+            # the door open).
+            continue
+            ;;
+    esac
+    # Convert any remaining backslashes to forward slashes for the
+    # filesystem check.
+    ref="${ref//\\//}"
+    if [ ! -f "$ref" ]; then
+        echo "MISSING: $path -> $ref"
+        missing=$((missing + 1))
+    fi
+done < <(grep -oE 'Include="\$\([^)]+\)\\[^"]+\.[chS]"' "$VCXPROJ" | sed -E 's/^Include="//; s/"$//')
+
+if [ "$missing" -gt 0 ]; then
+    echo
+    echo "ERROR: $missing of $total LibFFI.vcxproj refs missing from libffi $VERSION."
+    echo
+    echo "Either upstream renamed/removed files in this version (LibFFI.vcxproj"
+    echo "needs editing), or the project-local pregenerated headers are out of"
+    echo "date (re-run MagPython/update-libffi.sh to regenerate ffi.h, and"
+    echo "regenerate fficonfig.h on a Linux/macOS host per README's"
+    echo "'Updating pinned libffi' section)."
+    exit 1
+fi
+
+echo "OK: all $total LibFFI.vcxproj refs resolve in libffi $VERSION."

--- a/MagPython/check-libffi-drift.sh
+++ b/MagPython/check-libffi-drift.sh
@@ -46,18 +46,24 @@ missing=0
 total=0
 while IFS= read -r path; do
     total=$((total + 1))
+    # NOTE: single quotes preserve a literal single backslash. The
+    # vcxproj source uses one backslash between the variable and the
+    # path component (Include="$(VAR)\foo.h") — earlier versions of
+    # this script used '\\' which is two literal backslashes inside
+    # single quotes and silently never matched, falling through to
+    # the *) default and reporting a false-positive "all refs OK".
     case "$path" in
-        '$(LibFFITargetPregeneratedIncludeDir)\\'*)
-            ref="$PREGEN_DIR/${path#'$(LibFFITargetPregeneratedIncludeDir)\\'}"
+        '$(LibFFITargetPregeneratedIncludeDir)\'*)
+            ref="$PREGEN_DIR/${path#'$(LibFFITargetPregeneratedIncludeDir)\'}"
             ;;
-        '$(LibFFITargetSourceDir)\\'*)
-            ref="$SOURCE_DIR/src/x86/${path#'$(LibFFITargetSourceDir)\\'}"
+        '$(LibFFITargetSourceDir)\'*)
+            ref="$SOURCE_DIR/src/x86/${path#'$(LibFFITargetSourceDir)\'}"
             ;;
-        '$(LibFFISourceDir)\\'*)
-            ref="$SOURCE_DIR/src/${path#'$(LibFFISourceDir)\\'}"
+        '$(LibFFISourceDir)\'*)
+            ref="$SOURCE_DIR/src/${path#'$(LibFFISourceDir)\'}"
             ;;
-        '$(SourceDir)\\'*)
-            ref="$SOURCE_DIR/${path#'$(SourceDir)\\'}"
+        '$(SourceDir)\'*)
+            ref="$SOURCE_DIR/${path#'$(SourceDir)\'}"
             ;;
         *)
             # Skip ClCompile/ClInclude items that don't point into our

--- a/README.md
+++ b/README.md
@@ -685,6 +685,69 @@ Concurrency-grouped per `github.ref` with cancel-in-progress.
 `.github/dependabot.yaml` keeps the GitHub Actions versions current on a
 monthly cadence.
 
+`.github/workflows/Verify libffi drift.yml` runs on PRs that touch
+`MagPython/{libffi-version,libffi-sha256,LibFFI.vcxproj}`. It downloads
+the pinned libffi tarball on a Linux runner and confirms every `.c` /
+`.S` / `.h` file `LibFFI.vcxproj` references actually exists in the
+new tree — without this, drift only surfaces later as a cl.exe C1083
+error during a 5+ minute Windows build job. The drift logic lives in
+`MagPython/check-libffi-drift.sh` and is the libffi-specific
+counterpart to the per-file file-list management the Makefile-typed
+`ZLib.vcxproj` / `SQLite.vcxproj` / `LibMpdec.vcxproj` projects don't
+need (their file lists come from upstream's own makefile or from a
+single amalgamation file).
+
+## Auto-update via Renovate
+
+`.github/renovate.json` configures Renovate to open monthly version-
+bump PRs for the three pinned dependencies whose upstream is a
+GitHub repo:
+
+| Dep | Datasource | Filter |
+| --- | --- | --- |
+| openssl | `openssl/openssl` GitHub tags | `openssl-3.x.y` |
+| zlib | `madler/zlib` GitHub tags | `v1.x.y` |
+| libffi | `libffi/libffi` GitHub releases | `v3.x.y` |
+
+When Renovate opens a bump PR, it rewrites the `<dep>-version` pin and
+runs `MagPython/update-<dep>.sh <newVersion>` as a `postUpgradeTask`.
+That script downloads the new tarball, computes the SHA-256, and
+rewrites `<dep>-sha256` (and, for libffi, also regenerates
+`MagPython/libffi-msvc-include/ffi.h` from upstream's template). All
+three modified files end up in Renovate's PR commit.
+
+The other three pinned deps stay manually-bumped because their
+upstream isn't tracked by Renovate-supported datasources:
+
+- **sqlite** — sqlite.org's URL embeds a calendar-year segment that
+  isn't derivable from the version (see "Updating pinned SQLite"
+  above). Bump via `MagPython/update-sqlite.sh <version> <year>`.
+- **libmpdec** — bytereef.org has no Renovate-trackable release
+  feed. Bump via `MagPython/update-libmpdec.sh <version>`.
+- **NASM, jom** — build tools, rarely updated; bump via
+  `MagPython/update-nasm.sh <version>` / `MagPython/update-jom.sh
+  <version>` when you want to.
+
+### Self-host requirement for `postUpgradeTasks`
+
+Renovate's hosted (Mend) bot disables `postUpgradeTasks` by default
+on its public app — running arbitrary commands per PR is a privilege
+the cloud bot doesn't grant without explicit allowlist configuration.
+If this repo is using the public Mend Renovate, the version-pin update
+will land but the SHA-256 (and, for libffi, `ffi.h`) won't auto-refresh
+— CI will fail loudly with a clear "SHA-256 mismatch" error. Two
+recovery paths:
+
+1. **Self-host Renovate** in this repo's CI (an `.github/workflows/
+   renovate.yml` that runs the official renovate-action) and grant
+   it the right permissions; `postUpgradeTasks` then works.
+2. **Fix up Renovate's PR by hand** — fetch the branch, run
+   `MagPython/update-<dep>.sh <newVersion>`, push. The two extra
+   files land as a follow-up commit.
+
+Either way, the in-tree pin is the source of truth and CI's hash
+check protects against a stale SHA being merged.
+
 ## Licensing
 
 The vendored sources keep their upstream licenses:


### PR DESCRIPTION
## Summary

Closes the last item on the original devendoring plan: auto-update PRs for the version pins via Renovate, plus a CI guard against libffi's "upstream renamed a source file" failure mode.

This is independent of #42 (NASM + jom SHA pinning) — they can land in either order.

### Renovate config (`.github/renovate.json`)

Adds `customManagers` (regex datasource) for the three pinned deps whose upstream is a GitHub repo Renovate can track:

| dep | datasource | filter |
| --- | --- | --- |
| `openssl` | `github-tags openssl/openssl` | `^openssl-3\.\d+\.\d+$` |
| `zlib` | `github-tags madler/zlib` | `^v1\.\d+\.\d+$` |
| `libffi` | `github-releases libffi/libffi` | `^v3\.\d+\.\d+$` |

When Renovate bumps the `<dep>-version` pin, `postUpgradeTasks` runs `MagPython/update-<dep>.sh {{newVersion}}` (already in tree from #39 / #40). The script downloads the new tarball, computes SHA-256, and rewrites `<dep>-sha256` (plus `ffi.h` for libffi). All modified files land in Renovate's PR commit via the `fileFilters` allowlist.

`sqlite` (URL-embedded calendar year), `libmpdec` (bytereef.org, no Renovate datasource), and `NASM` / `jom` (build tools, rare bumps) stay manually-bumped via their respective `update-*.sh` scripts.

### `postUpgradeTasks` caveat — documented in README

Hosted Mend Renovate disables `postUpgradeTasks` by default. If this repo runs on the public bot rather than self-hosting, the version pin will land but the SHA won't auto-refresh and CI will fail loudly with the existing "SHA-256 mismatch" error. Two recovery paths:

1. Self-host Renovate (small workflow that runs `renovatebot/github-action`).
2. Fix up Renovate's PR by hand: `MagPython/update-<dep>.sh <newVersion>`, push.

The in-tree SHA pin remains the source of truth, and CI's hash check protects against a stale SHA being merged.

### Libffi drift CI

`LibFFI.vcxproj` is the only one of the new devendor subprojects that keeps a per-file `<ClCompile>` / `<CustomBuild>` / `<ClInclude>` list (libffi has no upstream MSVC build for x86_win32, so we drive the per-file compile ourselves). Without a check, an upstream rename or removal of a source file only surfaces at the next Windows build as a `cl.exe C1083 'cannot open source file'` error 5+ minutes into a metaproj build — and worse, may attribute to a PR that didn't actually cause it.

`.github/workflows/Verify libffi drift.yml` runs on PRs touching `MagPython/{libffi-version,libffi-sha256,LibFFI.vcxproj}`. It populates the libffi cache via `build-common.sh:setup_libffi` (download + SHA-256 verify + extract on a Linux runner — ~30s wall-clock), then runs `MagPython/check-libffi-drift.sh` which walks the vcxproj's `Include="$(...)\foo.{c,S,h}"` refs and verifies each exists in the libffi tree (or in `libffi-msvc-include/` for the project-local pregenerated headers).

Symmetric NEW-files detection (upstream added `.c` we should compile) is harder to automate without baseline drift bookkeeping; the libffi 3.x line is stable enough that GONE-only is the practical compromise.

Drift script tested locally on the current libffi 3.5.2 pin: **16 LibFFI.vcxproj refs all resolve cleanly**.

## Files

- **New** `.github/renovate.json` — customManagers + postUpgradeTasks config
- **New** `.github/workflows/Verify libffi drift.yml` — pull_request + workflow_dispatch
- **New** `MagPython/check-libffi-drift.sh` — drift script (bash 3.2-compatible, runs locally for debugging)
- **Modified** `README.md` — adds two new sections: "Auto-update via Renovate" + a workflow blurb under "Continuous integration"

## Test plan

- [ ] Renovate bot picks up the config, opens version-bump PRs for at least one of the three tracked deps when an upstream version is available. Verify the PR includes BOTH the version-pin update AND the SHA refresh (presence of the latter confirms `postUpgradeTasks` is enabled).
- [ ] If `postUpgradeTasks` is disabled (hosted bot), confirm the resulting CI failure is the expected "SHA-256 mismatch" error — not a confusing one. README documents the recovery.
- [ ] Manually trigger `Verify libffi drift` workflow (workflow_dispatch) on this PR's branch — should pass with "OK: all 16 LibFFI.vcxproj refs resolve in libffi 3.5.2."
- [ ] Negative test: tweak LibFFI.vcxproj on a throwaway PR to reference a nonexistent file (`foo_does_not_exist.c`); the workflow should fail with a clear MISSING line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyFnD51T7LNwhMb1SJZtaC)_