### PR TITLE
Exercise sqlite3 in smoke test and verify deps are pinned, not system

### DIFF
--- a/MagPython/MagPython-config.c
+++ b/MagPython/MagPython-config.c
@@ -105,6 +105,10 @@ extern PyObject* PyInit__hashlib(void);
 extern PyObject* PyInit__socket(void);
 extern PyObject* PyInit_select(void);
 extern PyObject* PyInit_unicodedata(void);
+extern PyObject* PyInit__sqlite3(void);
+extern PyObject* PyInit__decimal(void);
+extern PyObject* PyInit__asyncio(void);
+extern PyObject* PyInit__queue(void);
 
 /* tools/freeze/makeconfig.py marker for additional "extern" */
 /* -- ADDMODULE MARKER 1 -- */
@@ -191,6 +195,10 @@ struct _inittab _PyImport_Inittab[] = {
     {"_socket", PyInit__socket},
     {"select", PyInit_select},
     {"unicodedata", PyInit_unicodedata},
+    {"_sqlite3", PyInit__sqlite3},
+    {"_decimal", PyInit__decimal},
+    {"_asyncio", PyInit__asyncio},
+    {"_queue", PyInit__queue},
 
 /* tools/freeze/makeconfig.py marker for additional "_inittab" entries */
 /* -- ADDMODULE MARKER 2 -- */

--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -201,37 +201,97 @@ build_static_deps() {
 # so the vcxproj's $(PythonSourceDir) substitution keeps a clean
 # python-$(PythonVersion)/ shape.
 setup_python() {
-    if [ -d "$PYTHON_SRC" ]; then return 0; fi
+    if [ ! -d "$PYTHON_SRC" ]; then
+        log "Fetching CPython $PYTHON_VERSION"
+        mkdir -p "$PYTHON_CACHE"
+        local url="https://github.com/python/cpython/archive/refs/tags/v$PYTHON_VERSION.tar.gz"
+        local tarball="$PYTHON_CACHE/cpython-$PYTHON_VERSION.tar.gz"
 
-    log "Fetching CPython $PYTHON_VERSION"
-    mkdir -p "$PYTHON_CACHE"
-    local url="https://github.com/python/cpython/archive/refs/tags/v$PYTHON_VERSION.tar.gz"
-    local tarball="$PYTHON_CACHE/cpython-$PYTHON_VERSION.tar.gz"
+        if [ ! -f "$tarball" ]; then
+            curl --fail --silent --show-error --location \
+                -o "$tarball" "$url"
+        fi
 
-    if [ ! -f "$tarball" ]; then
-        curl --fail --silent --show-error --location \
-            -o "$tarball" "$url"
+        local sha256_cmd
+        if command -v shasum >/dev/null 2>&1; then sha256_cmd="shasum -a 256"
+        elif command -v sha256sum >/dev/null 2>&1; then sha256_cmd="sha256sum"
+        else echo "Need shasum or sha256sum" >&2; exit 1; fi
+        local actual
+        actual="$($sha256_cmd "$tarball" | awk '{print $1}')"
+        if [ "$PYTHON_SHA256" != "$actual" ]; then
+            echo "CPython SHA-256 mismatch: expected $PYTHON_SHA256, got $actual" >&2
+            echo "  (pinned in MagPython/python-sha256 — regenerate via" >&2
+            echo "   MagPython/update-python.sh before changing)" >&2
+            rm -f "$tarball"
+            exit 1
+        fi
+
+        tar -xzf "$tarball" -C "$PYTHON_CACHE"
+        # Upstream tag archive extracts to cpython-<version>/. Rename for
+        # path symmetry with the other devendored deps (and so $PYTHON_SRC
+        # stays a clean python-<version>/ path).
+        mv "$PYTHON_CACHE/cpython-$PYTHON_VERSION" "$PYTHON_SRC"
     fi
 
-    local sha256_cmd
-    if command -v shasum >/dev/null 2>&1; then sha256_cmd="shasum -a 256"
-    elif command -v sha256sum >/dev/null 2>&1; then sha256_cmd="sha256sum"
-    else echo "Need shasum or sha256sum" >&2; exit 1; fi
-    local actual
-    actual="$($sha256_cmd "$tarball" | awk '{print $1}')"
-    if [ "$PYTHON_SHA256" != "$actual" ]; then
-        echo "CPython SHA-256 mismatch: expected $PYTHON_SHA256, got $actual" >&2
-        echo "  (pinned in MagPython/python-sha256 — regenerate via" >&2
-        echo "   MagPython/update-python.sh before changing)" >&2
-        rm -f "$tarball"
-        exit 1
-    fi
+    # Always run the patch — the GitHub Actions workflow caches
+    # MagPython/python/ by python-version+sha256, so a fresh download
+    # only happens when the pin moves. On a cache hit, the cached
+    # source tree may pre-date this patch and needs it applied
+    # against. patch_cpython_configure is idempotent: it skips silently
+    # if the marker is already gone.
+    patch_cpython_configure
+}
 
-    tar -xzf "$tarball" -C "$PYTHON_CACHE"
-    # Upstream tag archive extracts to cpython-<version>/. Rename for
-    # path symmetry with the other devendored deps (and so $PYTHON_SRC
-    # stays a clean python-<version>/ path).
-    mv "$PYTHON_CACHE/cpython-$PYTHON_VERSION" "$PYTHON_SRC"
+# Patch CPython's pre-built configure script to stop the Darwin libffi
+# block from clobbering user-supplied LIBFFI_CFLAGS / LIBFFI_LIBS.
+#
+# CPython 3.13's configure.ac (and the generated configure shell script)
+# has a hard-coded block that runs only on Darwin:
+#
+#     have_libffi=missing
+#     if test "x$ac_sys_system" = xDarwin; then
+#         CFLAGS="-I${SDKROOT}/usr/include/ffi $CFLAGS"
+#         <AC_CHECK_HEADER([ffi.h]) + AC_CHECK_LIB([ffi], [ffi_call])>
+#         if both checks pass:
+#             have_libffi=yes
+#             LIBFFI_CFLAGS="-I${SDKROOT}/usr/include/ffi -DUSING_APPLE_OS_LIBFFI=1"
+#             LIBFFI_LIBS="-lffi"
+#         fi
+#     fi
+#
+# On any modern macOS the SDK's <ffi.h> is reachable and `-lffi` resolves
+# to /usr/lib/libffi.dylib (or a Homebrew copy), so the inner assignments
+# always run — and they unconditionally OVERWRITE the user-passed
+# LIBFFI_CFLAGS / LIBFFI_LIBS we set in configure_libmagpython. The
+# subsequent fallback PKG_CHECK_MODULES block (which would honour our env
+# vars) is gated on `have_libffi=missing`, so it's skipped. End result:
+# _ctypes compiles against the SDK's ffi.h and links against
+# /usr/lib/libffi.dylib instead of our pinned static libffi.a, leaving
+# libMagPython.dylib with a NEEDED dependency on system libffi.
+#
+# Drop just the two assignment lines; have_libffi=yes still gets set, so
+# the configure flow proceeds normally with our env-supplied LIBFFI_*
+# values intact. The Linux/Windows builds never enter this block (the
+# `xDarwin` test is false), so the patch is a no-op there.
+#
+# Idempotent: the marker (USING_APPLE_OS_LIBFFI=1) only exists in the
+# pre-patched source, so re-running on an already-patched tree no-ops.
+patch_cpython_configure() {
+    local f="$PYTHON_SRC/configure"
+    if ! grep -q 'USING_APPLE_OS_LIBFFI=1' "$f"; then
+        # Already patched (or upstream removed the marker entirely).
+        return 0
+    fi
+    log "Patching CPython configure: skip Darwin LIBFFI_* overwrite"
+    # Markers chosen to be unique to this block: USING_APPLE_OS_LIBFFI
+    # appears nowhere else, and the bare `LIBFFI_LIBS="-lffi"` form
+    # (no ${VAR-default}) is only in this block — the fallback uses
+    # `LIBFFI_LIBS=${LIBFFI_LIBS-"-lffi"}` which our pattern excludes.
+    sed -i.bak \
+        -e '/USING_APPLE_OS_LIBFFI=1/d' \
+        -e '/^[[:space:]]*LIBFFI_LIBS="-lffi"$/d' \
+        "$f"
+    rm -f "$f.bak"
 }
 
 # Download + verify + extract the upstream zlib tarball into
@@ -709,9 +769,25 @@ configure_libmagpython() {
     # CPython's configure has --with-system-libmpdec on by default and
     # uses pkg-config; with no .pc on PATH it falls back to "-lmpdec -lm"
     # ELSE the user-supplied LIBMPDEC_CFLAGS / LIBMPDEC_LIBS. Pointing the
-    # latter at the static .a we just built mirrors how zlib / sqlite /
-    # libffi are wired in, and stops _decimal from picking up a system
-    # libmpdec instead.
+    # latter at the static .a we just built mirrors how zlib and libffi
+    # are wired in, and stops _decimal from picking up a system libmpdec
+    # instead.
+    #
+    # sqlite3 is wired in as -L<dir> -lsqlite3 rather than a bare .a
+    # path because configure runs AC_CHECK_LIB([sqlite3], ...) probes
+    # that prepend a literal -lsqlite3 to the link line; on hosts
+    # without sqlite-devel that prepended -l can't be resolved (the
+    # linker only sees our $BUILD/sqlite directory via LIBSQLITE3_LIBS
+    # AFTER the -l, which is too late) and configure marks
+    # have_supported_sqlite3=no, dropping _sqlite3 from the build.
+    # Pre-cache the probe results below so AC_CHECK_LIB never runs the
+    # link tests at all — have_supported_sqlite3 stays yes regardless
+    # of how the host's linker would resolve `-lsqlite3`. The actual
+    # `_sqlite3` build link still uses LIBSQLITE3_LIBS, where our -L
+    # IS in effect (no AC_CHECK_LIB-prepended -l ahead of it), so the
+    # linker picks our pinned libsqlite3.a (the only file in
+    # $BUILD/sqlite). Pre-caching is robust to linker quirks (e.g. ld
+    # implementations that prefer .so across all -L dirs over .a in any).
     "$PYTHON_SRC/configure" \
         --enable-shared \
         --without-static-libpython \
@@ -726,7 +802,7 @@ configure_libmagpython() {
         ZLIB_CFLAGS="-I$ZLIB_SRC" \
         ZLIB_LIBS="$ZLIB_SRC/libz.a" \
         LIBSQLITE3_CFLAGS="-I$SQLITE_SRC" \
-        LIBSQLITE3_LIBS="$BUILD/sqlite/libsqlite3.a" \
+        LIBSQLITE3_LIBS="-L$BUILD/sqlite -lsqlite3" \
         LIBMPDEC_CFLAGS="-I$BUILD/libmpdec-out/include" \
         LIBMPDEC_LIBS="$BUILD/libmpdec-out/lib/libmpdec.a -lm" \
         CURSES_CFLAGS="-DHAVE_NCURSESW=1 -I$BUILD/ncurses-out/include -I$BUILD/ncurses-out/include/ncursesw" \
@@ -735,6 +811,17 @@ configure_libmagpython() {
         PANEL_LIBS="$BUILD/ncurses-out/lib/libpanelw.a $BUILD/ncurses-out/lib/libncursesw.a" \
         CFLAGS_NODIST="-fPIC" \
         LDFLAGS_NODIST="$extra_ldflags" \
+        ac_cv_lib_sqlite3_sqlite3_bind_double=yes \
+        ac_cv_lib_sqlite3_sqlite3_column_decltype=yes \
+        ac_cv_lib_sqlite3_sqlite3_column_double=yes \
+        ac_cv_lib_sqlite3_sqlite3_complete=yes \
+        ac_cv_lib_sqlite3_sqlite3_progress_handler=yes \
+        ac_cv_lib_sqlite3_sqlite3_result_double=yes \
+        ac_cv_lib_sqlite3_sqlite3_set_authorizer=yes \
+        ac_cv_lib_sqlite3_sqlite3_trace_v2=yes \
+        ac_cv_lib_sqlite3_sqlite3_value_double=yes \
+        ac_cv_lib_sqlite3_sqlite3_load_extension=yes \
+        ac_cv_lib_sqlite3_sqlite3_serialize=yes \
         "$@"
 }
 
@@ -829,8 +916,62 @@ stage_headers_and_stdlib() {
         | (cd "$STAGE/lib/python$PY_X_Y" && tar -xf -)
 }
 
+# Verify $1 (the libMagPython artifact) has no dynamic linkage to any of
+# the deps we statically bundle. A leakage here means the build picked
+# up a system libsqlite3 / libmpdec / libffi / libz at link time despite
+# our LIBxxx_LIBS / LIBxxx_CFLAGS settings — which can happen if the
+# build host has the matching -dev package installed and its
+# /usr/lib<arch> happens to be searched ahead of our $BUILD/<dep>
+# directory by the linker. The configure-time AC_CHECK_LIB probes can
+# also inadvertently pull in a system .so when AC_CHECK_LIB prepends
+# `-lsqlite3` to LIBS without our `-L` first. Both failure modes are
+# invisible at configure time and to the structural built-in-module
+# check in test.c (the C extension is still in libMagPython, it's just
+# *calling* the system .so for sqlite3 functions). Only post-link
+# inspection catches it.
+verify_no_static_dep_leakage() {
+    local libpath="$1"
+    log "Verifying $(basename "$libpath") has no dynamic linkage to bundled deps"
+    local deps
+    case "$(uname -s)" in
+        Linux)
+            # readelf -d prints NEEDED entries as `[libname.so.N]`.
+            deps="$(readelf -d "$libpath" | awk '/NEEDED/ { gsub(/[][]/, "", $5); print $5 }')"
+            ;;
+        Darwin)
+            # otool -L's first line is the file itself; subsequent lines
+            # are LC_LOAD_DYLIB references (`<path> (compatibility ...)`).
+            deps="$(otool -L "$libpath" | tail -n +2 | awk '{ print $1 }')"
+            ;;
+        *)
+            echo "verify_no_static_dep_leakage: unsupported OS $(uname -s)" >&2
+            return 1
+            ;;
+    esac
+    local forbidden hit fail=0
+    # libsqlite3 / libmpdec / libffi / libz are all statically linked into
+    # libMagPython and must not appear as a runtime dependency. libssl /
+    # libcrypto are intentionally *not* in this list — they're the one dep
+    # we ship as sibling .so/.dylib files (test.c verifies the loaded path).
+    for forbidden in libsqlite3 libmpdec libffi libz; do
+        hit="$(printf '%s\n' "$deps" | grep -E "(^|/)$forbidden\\.(so|dylib)" || true)"
+        if [ -n "$hit" ]; then
+            echo "ERROR: $libpath dynamically links $forbidden — bundled .a was not used:" >&2
+            printf '  %s\n' $hit >&2
+            fail=1
+        fi
+    done
+    if [ "$fail" -ne 0 ]; then
+        echo "Inspect LIBSQLITE3_LIBS / LIBMPDEC_LIBS / LIBFFI / ZLIB_LIBS in" >&2
+        echo "configure_libmagpython and the build host's installed -dev packages." >&2
+        exit 1
+    fi
+}
+
 # Build and run the smoke test (MagPython/test.c) against the staged tree.
 # $1: rpath token ('$ORIGIN' on Linux, '@loader_path' on macOS).
+# $2..: extra link args (e.g. '-ldl' on Linux for dladdr; macOS has it
+#       in libSystem and Windows in kernel32, so no extra arg there).
 #
 # The cc invocation deliberately uses ONLY $STAGE for both -I and -L: the
 # build dir's openssl-out/ and CPython build outputs are off the search path,
@@ -838,13 +979,14 @@ stage_headers_and_stdlib() {
 # libssl.<ver>.dylib) in the artifact is a hard failure here rather than a
 # silent fallback to the build tree.
 run_smoke_test() {
-    local rpath_token="$1"
+    local rpath_token="$1"; shift
     log "Building smoke test"
     cc "$REPO/MagPython/test.c" \
         -I"$STAGE/include" \
         -L"$STAGE" \
         "-Wl,-rpath,${rpath_token}" \
         -lMagPython -lssl -lcrypto \
+        "$@" \
         -o "$STAGE/MagPython_test"
     log "Running smoke test"
     # No PYTHONPATH/PYTHONHOME needed: stage_headers_and_stdlib added a

--- a/MagPython/build-linux.sh
+++ b/MagPython/build-linux.sh
@@ -111,6 +111,7 @@ done
 stage_headers_and_stdlib "$BUILD/main"
 stage_openssl_headers
 stage_licenses
-run_smoke_test '$ORIGIN'
+verify_no_static_dep_leakage "$STAGE/libMagPython.so"
+run_smoke_test '$ORIGIN' -ldl
 
 zip_artifact linux-x86_64

--- a/MagPython/build-macos.sh
+++ b/MagPython/build-macos.sh
@@ -153,6 +153,7 @@ done
 stage_headers_and_stdlib "$BUILD/main"
 stage_openssl_headers
 stage_licenses
+verify_no_static_dep_leakage "$STAGE/libMagPython.dylib"
 run_smoke_test '@loader_path'
 
 # Sanity: only @rpath/* and system libs should remain in the LC_LOAD_DYLIB

--- a/MagPython/test.c
+++ b/MagPython/test.c
@@ -4,6 +4,23 @@
 #include <openssl/ssl.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <dlfcn.h>
+#  include <limits.h>
+#endif
+#ifdef __APPLE__
+#  include <mach-o/dyld.h>
+#endif
+
+#ifdef _WIN32
+#  define PATH_SEP '\\'
+#else
+#  define PATH_SEP '/'
+#endif
 
 static int try_import(const char *module) {
     PyObject *m = PyImport_ImportModule(module);
@@ -17,13 +34,77 @@ static int try_import(const char *module) {
     return 0;
 }
 
+// Resolve the directory containing this executable. Used by the OpenSSL
+// path-of-loaded-lib check below to verify libcrypto was loaded from the
+// artifact's own dir (where build-{linux,macos}.sh / test.vcxproj stage
+// it) rather than a same-version copy elsewhere on the system.
+static int get_exe_dir(char *out, size_t out_size) {
+    char path[4096];
+#ifdef _WIN32
+    DWORD n = GetModuleFileNameA(NULL, path, (DWORD)sizeof(path));
+    if (n == 0 || n >= sizeof(path)) return -1;
+#elif defined(__APPLE__)
+    uint32_t size = sizeof(path);
+    if (_NSGetExecutablePath(path, &size) != 0) return -1;
+    char resolved[4096];
+    if (realpath(path, resolved) == NULL) return -1;
+    if (strlen(resolved) >= sizeof(path)) return -1;
+    strcpy(path, resolved);
+#else
+    ssize_t n = readlink("/proc/self/exe", path, sizeof(path) - 1);
+    if (n <= 0 || (size_t)n >= sizeof(path)) return -1;
+    path[n] = '\0';
+#endif
+    char *slash = strrchr(path, PATH_SEP);
+    if (slash == NULL) return -1;
+    *slash = '\0';
+    if (strlen(path) + 1 > out_size) return -1;
+    strcpy(out, path);
+    return 0;
+}
+
+// Resolve the absolute path of the shared library that owns `addr`. On
+// POSIX this is dladdr -> dli_fname (canonicalized via realpath because
+// dladdr can return the lookup name rather than the loaded path); on
+// Windows it's GetModuleHandleEx(FROM_ADDRESS) -> GetModuleFileName.
+static int get_lib_path_for(void *addr, char *out, size_t out_size) {
+#ifdef _WIN32
+    HMODULE h;
+    if (!GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCSTR)addr, &h)) {
+        return -1;
+    }
+    DWORD n = GetModuleFileNameA(h, out, (DWORD)out_size);
+    if (n == 0 || n >= out_size) return -1;
+    return 0;
+#else
+    Dl_info info;
+    if (dladdr(addr, &info) == 0 || info.dli_fname == NULL) return -1;
+    char resolved[4096];
+    if (realpath(info.dli_fname, resolved) == NULL) return -1;
+    if (strlen(resolved) + 1 > out_size) return -1;
+    strcpy(out, resolved);
+    return 0;
+#endif
+}
+
 // Exercise OpenSSL directly (not just through Python's _ssl) so the artifact
 // is validated as a usable OpenSSL SDK: the headers must be present at
 // compile time, the libcrypto/libssl import lib (Windows) or unversioned
 // symlink (Linux/macOS) must be present at link time, and the shared lib
-// must resolve at runtime via the artifact's rpath. Also compares the
-// header's compile-time version against libcrypto's runtime version to
-// catch a header/lib mismatch.
+// must resolve at runtime via the artifact's rpath.
+//
+// Two consistency checks: the header's compile-time version must equal
+// libcrypto's runtime version (catches a header/lib version skew), and
+// the loaded libcrypto must live in the same directory as this binary
+// (catches a system libcrypto.<so|dylib|dll> with a matching version
+// being picked up via LD_LIBRARY_PATH / DYLD_LIBRARY_PATH / PATH ahead
+// of the artifact's $ORIGIN / @loader_path / DLL search dir). The path
+// check is what makes the openssl validation robust to a system shipping
+// the same OpenSSL version as our pin — version-string match alone can't
+// distinguish "loaded ours" from "loaded system's".
 static int exercise_openssl(void) {
     const char *header_ver = OPENSSL_VERSION_TEXT;
     const char *runtime_ver = OpenSSL_version(OPENSSL_VERSION);
@@ -33,6 +114,34 @@ static int exercise_openssl(void) {
         fprintf(stderr, "  OpenSSL header/runtime version mismatch\n");
         return -1;
     }
+
+    char exe_dir[4096], lib_path[4096];
+    if (get_exe_dir(exe_dir, sizeof(exe_dir)) != 0) {
+        fprintf(stderr, "  failed to resolve test binary directory\n");
+        return -1;
+    }
+    // OpenSSL_version_num lives in libcrypto, so its load address
+    // identifies which libcrypto was actually mapped into the process.
+    if (get_lib_path_for((void *)(uintptr_t)OpenSSL_version_num,
+                         lib_path, sizeof(lib_path)) != 0) {
+        fprintf(stderr, "  failed to resolve loaded libcrypto path\n");
+        return -1;
+    }
+    char *slash = strrchr(lib_path, PATH_SEP);
+    if (slash == NULL) {
+        fprintf(stderr, "  unexpected libcrypto path: %s\n", lib_path);
+        return -1;
+    }
+    *slash = '\0';
+    if (strcmp(exe_dir, lib_path) != 0) {
+        fprintf(stderr,
+                "  libcrypto loaded from %s, expected %s (same dir as test exe)\n",
+                lib_path, exe_dir);
+        return -1;
+    }
+    *slash = PATH_SEP;
+    printf("  OpenSSL loaded from: %s\n", lib_path);
+
     if (OPENSSL_init_ssl(0, NULL) != 1) {
         fprintf(stderr, "  OPENSSL_init_ssl FAILED\n");
         return -1;
@@ -84,6 +193,7 @@ int main(int argc, char *argv[]) {
     failures += try_import("ssl") != 0;
     failures += try_import("ctypes") != 0;
     failures += try_import("hashlib") != 0;
+    failures += try_import("sqlite3") != 0;
 
     // Exercise each module a little to make sure the C extensions
     // actually load and not just the Python wrappers. The crypto block
@@ -94,7 +204,7 @@ int main(int argc, char *argv[]) {
     // _hashopenssl wraps. The TLS block sanity-checks libssl's cipher
     // list and an in-process MemoryBIO TLS handshake (no network).
     rc = PyRun_SimpleString(
-        "import decimal, ssl, ctypes, ctypes.util, hashlib, hmac, secrets\n"
+        "import decimal, ssl, ctypes, ctypes.util, hashlib, hmac, secrets, sqlite3\n"
         "\n"
         "assert decimal.Decimal('1.1') + decimal.Decimal('2.2') == decimal.Decimal('3.3'), 'decimal arithmetic'\n"
         "print('  ctypes find_library(c):', ctypes.util.find_library('c'))\n"
@@ -141,7 +251,41 @@ int main(int argc, char *argv[]) {
         "try: sock.do_handshake()\n"
         "except ssl.SSLWantReadError: pass\n"
         "assert out_bio.pending > 0, 'libssl produced no ClientHello bytes'\n"
-        "print('  TLS ClientHello bytes:', out_bio.pending)\n");
+        "print('  TLS ClientHello bytes:', out_bio.pending)\n"
+        "\n"
+        "# Verify the C extensions backed by our pinned static deps are\n"
+        "# actually built into libMagPython rather than loaded from a\n"
+        "# system .so/.pyd. __spec__.origin == 'built-in' iff the module\n"
+        "# was registered via _PyImport_Inittab (which the project does\n"
+        "# from MagPython-config.c on Windows and from a flipped\n"
+        "# Setup.stdlib + Setup.local on Unix). Together with the static\n"
+        "# linkage of libsqlite3.a / libmpdec.a / libz.a / libffi.a into\n"
+        "# libMagPython, this is what guarantees we're using OUR pinned\n"
+        "# dep at runtime — a version-string match could be a coincidence\n"
+        "# if the host happens to ship the same upstream version.\n"
+        "import _sqlite3, _decimal, _ctypes, _ssl, _hashlib, zlib\n"
+        "for _mod in (_sqlite3, _decimal, zlib, _ctypes, _ssl, _hashlib):\n"
+        "    _origin = _mod.__spec__.origin\n"
+        "    assert _origin == 'built-in', \\\n"
+        "        f'{_mod.__name__} is not built-in (origin={_origin!r}); a non-pinned copy may have been loaded'\n"
+        "print('  built-in C extensions verified: _sqlite3, _decimal, zlib, _ctypes, _ssl, _hashlib')\n"
+        "\n"
+        "# Exercise the bundled SQLite via the _sqlite3 C extension: open\n"
+        "# an in-memory DB, run DDL/DML with parameter binding, commit a\n"
+        "# transaction, and read it back through an aggregate. Touches the\n"
+        "# prepare/bind/step/finalize path plus the type adapters.\n"
+        "print('  sqlite3 sqlite_version:', sqlite3.sqlite_version)\n"
+        "con = sqlite3.connect(':memory:')\n"
+        "con.execute('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, n REAL)')\n"
+        "con.executemany('INSERT INTO t (name, n) VALUES (?, ?)',\n"
+        "                [('alpha', 1.5), ('beta', 2.5), ('gamma', 4.0)])\n"
+        "con.commit()\n"
+        "rows = con.execute('SELECT name, n FROM t ORDER BY id').fetchall()\n"
+        "assert rows == [('alpha', 1.5), ('beta', 2.5), ('gamma', 4.0)], rows\n"
+        "(total,) = con.execute('SELECT SUM(n) FROM t').fetchone()\n"
+        "assert total == 8.0, total\n"
+        "con.close()\n"
+        "print('  sqlite3 rows:', len(rows), 'sum:', total)\n");
     if (rc != 0) {
         failures += 1;
     }


### PR DESCRIPTION
## Summary

The original goal — exercise sqlite3 in the smoke test instead of just importing it — turned out to be the small part. The bigger work is making the smoke test prove the artifact uses our pinned deps rather than whatever happens to be on the build / test host, and fixing the build-wiring gaps that surfaced once the checks ran.

## Smoke-test additions (`MagPython/test.c`)

* **sqlite3 exercise.** In-memory DB roundtrip — DDL, parameter binding via `executemany`, commit, `SELECT`, `SUM` aggregate — so `_sqlite3` is exercised end-to-end. Prints `sqlite_version` for visibility.
* **Structural built-in check.** Asserts `__spec__.origin == 'built-in'` for `_sqlite3`, `_decimal`, `_ctypes`, `zlib`, `_ssl`, `_hashlib`. A built-in module can only live inside `libMagPython` itself, so this proves the wrappers came from our build (transitively, the static deps baked in too).
* **OpenSSL path check.** OpenSSL is the one dep we ship as a sibling `.so`/`.dylib`/`.dll`, so a same-version system copy can substitute for it at runtime via `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` / DLL search order. Resolve the loaded `libcrypto`'s path via `dladdr(OpenSSL_version_num)` (POSIX) or `GetModuleHandleEx(FROM_ADDRESS)` + `GetModuleFileName` (Windows) and assert it matches the test binary's directory.

Why structural rather than version-string matching: if the host happens to ship the same upstream version as our pin, a version-only check passes silently against the wrong copy.

## Post-link verification (`build-common.sh`)

New `verify_no_static_dep_leakage` inspects `libMagPython.{so,dylib}` via `readelf -d` (Linux) / `otool -L` (macOS) and fails the build if `libsqlite3` / `libmpdec` / `libffi` / `libz` show up as a `NEEDED` / `LC_LOAD_DYLIB` entry. Catches the case where `_sqlite3` (etc.) is technically built-in but its underlying static dep was substituted with a system shared library at link time. Wired into `build-linux.sh` and `build-macos.sh` between staging and the smoke test. Windows isn't covered: nothing on Windows auto-resolves `-l<name>` to a system DLL and `MagPython.vcxproj` references our `sqlite3.lib` explicitly, so the failure mode doesn't apply.

`libssl` / `libcrypto` are deliberately excluded — those are the deps shipped as siblings, and the OpenSSL path check above handles them.

## Build-wiring gaps surfaced

* **Windows — missing `_PyImport_Inittab` entries.** `MagPython-config.c` was missing rows for several extensions whose `.c` sources are compiled into `MagPython.dll`, so `import <name>` falls through to the disabled dynamic-loading path. Added entries for `_decimal` and `_sqlite3` (long-standing — `_decimal` was masked by `decimal.py`'s silent `_pydecimal` fallback) plus `_asyncio` and `_queue` (introduced by upstream PR #49 which added the `ClCompile` entries without registering the inittab rows).
* **Linux — `_sqlite3` configure probe.** `configure.ac:4316-4326` runs `AC_CHECK_LIB([sqlite3], FUNC)` probes that prepend a literal `-lsqlite3` to the link line. On hosts without `sqlite-devel` (e.g. the manylinux container) the prepended `-l` can't be resolved, configure marks `have_supported_sqlite3=no`, and `_sqlite3` gets dropped from the build. Pre-cache `ac_cv_lib_sqlite3_<func>=yes` for every `PY_CHECK_SQLITE_FUNC` probe so `AC_CHECK_LIB` short-circuits to the cached value and never runs the link test. The actual `_sqlite3` build still uses `LIBSQLITE3_LIBS=-L$BUILD/sqlite -lsqlite3`, where `-L` is in effect ahead of the `-l`, so the linker picks our pinned `libsqlite3.a`.
* **macOS — Darwin libffi override.** `configure.ac:4076-4088` has a hard-coded Darwin-only block that runs `AC_CHECK_HEADER([ffi.h])` + `AC_CHECK_LIB([ffi], [ffi_call])` with `-I${SDKROOT}/usr/include/ffi` prepended, and on success unconditionally **overwrites** the user-supplied `LIBFFI_CFLAGS` / `LIBFFI_LIBS` with the SDK system libffi. Result: `_ctypes` compiled against the SDK's `ffi.h` and linked against `/usr/lib/libffi.dylib` instead of our pinned static `libffi.a`. Sed-patch CPython's pre-built `configure` script in `setup_python` to delete just the two `LIBFFI_*` assignment lines; `have_libffi=yes` is still set so configure proceeds normally with our env-supplied values intact. The patch is idempotent and runs on every `setup_python` invocation, including cache hits — `Build All.yml` caches `MagPython/python/` by `python-version+sha256`, so a cache hit on a source tree extracted before this patch existed still gets it applied in place.

## Test plan

- [ ] All three platforms build cleanly (Linux x86_64, macOS arm64, Windows)
- [ ] Smoke test passes on all three — should print `OpenSSL loaded from: <stage dir>`, `built-in C extensions verified: ...`, `sqlite3 rows: 3 sum: 8.0`
- [ ] `verify_no_static_dep_leakage` runs successfully (Linux / macOS) — no `NEEDED` / `LC_LOAD_DYLIB` for `libsqlite3` / `libmpdec` / `libffi` / `libz`
- [ ] `import _asyncio`, `import _queue`, `import _decimal`, `import _sqlite3` all succeed on Windows

https://claude.ai/code/session_01KNa3wngtW24HZ7cNG8w6ua