### PR TITLE
Enable _asyncio and _queue on all platforms

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -37,12 +37,13 @@ Versions are pinned in `MagPython/<dep>-version` and SHA-256 in
 All three platforms ship the same module surface (modulo `_winapi`,
 Windows-only).
 
-Core / runtime: `_abc`, `_codecs`, `_collections`, `_contextvars`,
-`_functools`, `_io`, `_locale`, `_opcode`, `_operator`, `_signal`,
-`_sre`, `_stat`, `_string`, `_suggestions`, `_symtable`, `_sysconfig`,
-`_thread`, `_tracemalloc`, `_typing`, `_warnings`, `_weakref`, `atexit`,
-`builtins`, `errno`, `faulthandler`, `gc`, `itertools`, `marshal`,
-`posix` (Unix) / `nt` (Windows), `sys`, `time`, `xxsubtype`.
+Core / runtime: `_abc`, `_asyncio`, `_codecs`, `_collections`,
+`_contextvars`, `_functools`, `_io`, `_locale`, `_opcode`, `_operator`,
+`_queue`, `_signal`, `_sre`, `_stat`, `_string`, `_suggestions`,
+`_symtable`, `_sysconfig`, `_thread`, `_tracemalloc`, `_typing`,
+`_warnings`, `_weakref`, `atexit`, `builtins`, `errno`, `faulthandler`,
+`gc`, `itertools`, `marshal`, `posix` (Unix) / `nt` (Windows), `sys`,
+`time`, `xxsubtype`.
 
 Data / numerics: `_bisect`, `_csv`, `_datetime`, `_decimal` (libmpdec),
 `_heapq`, `_json`, `_lsprof`, `_pickle`, `_random`, `_statistics`,
@@ -71,16 +72,15 @@ Windows-only: `_winapi`.
 Not built into the library, so any pure-Python stdlib that `import`s
 them will fail (canonical list: `MagPython/Setup.local`):
 
-`_asyncio`, `_bz2`, `_crypt`, `_dbm`, `_elementtree`, `_gdbm`,
-`_lzma`, `_multiprocessing`, `_posixshmem`, `_queue`, `_scproxy`,
-`_testbuffer`, `_testcapi`, `_testclinic`, `_testimportmultiple`,
+`_bz2`, `_crypt`, `_dbm`, `_elementtree`, `_gdbm`, `_lzma`,
+`_multiprocessing`, `_posixshmem`, `_scproxy`, `_testbuffer`,
+`_testcapi`, `_testclinic`, `_testimportmultiple`,
 `_testinternalcapi`, `_testmultiphase`, `_testsinglephase`,
-`_tkinter`, `_uuid`, `_xxtestfuzz`, `_zoneinfo`, `nis`,
-`ossaudiodev`, `pyexpat`, `readline`, `spwd`, `xxlimited`,
-`xxlimited_35`.
+`_tkinter`, `_uuid`, `_xxtestfuzz`, `_zoneinfo`, `nis`, `ossaudiodev`,
+`pyexpat`, `readline`, `spwd`, `xxlimited`, `xxlimited_35`.
 
-User-visible consequences include: no `asyncio`, `bz2`, `lzma`,
-`multiprocessing`, `queue`, `tkinter`, `uuid` (the C accelerator;
+User-visible consequences include: no `bz2`, `lzma`,
+`multiprocessing`, `tkinter`, `uuid` (the C accelerator;
 the pure-Python parts of `uuid` still import), `zoneinfo`, `dbm`,
 `xml.etree` (no `pyexpat`). `curses` is POSIX-only — Windows ships
 no `_curses` (CPython upstream relies on the `windows-curses` PyPI

--- a/MagPython/MagPython.vcxproj
+++ b/MagPython/MagPython.vcxproj
@@ -360,6 +360,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(PythonSourceDir)\Modules\_abc.c" />
+    <ClCompile Include="$(PythonSourceDir)\Modules\_asynciomodule.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_bisectmodule.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_blake2\blake2module.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_blake2\blake2b_impl.c" />
@@ -378,6 +379,7 @@
     <ClCompile Include="$(PythonSourceDir)\Modules\_localemodule.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_lsprof.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_pickle.c" />
+    <ClCompile Include="$(PythonSourceDir)\Modules\_queuemodule.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_randommodule.c" />
     <ClCompile Include="$(PythonSourceDir)\Modules\_sre\sre.c" />
     <ClInclude Include="$(PythonSourceDir)\Modules\_sre\sre.h" />

--- a/MagPython/Setup.local
+++ b/MagPython/Setup.local
@@ -8,7 +8,6 @@
 # platforms ship the same Python surface to the host application.
 
 *disabled*
-_asyncio
 _bz2
 _crypt
 _dbm
@@ -17,7 +16,6 @@ _gdbm
 _lzma
 _multiprocessing
 _posixshmem
-_queue
 _scproxy
 _testbuffer
 _testcapi


### PR DESCRIPTION
Both are single-source CPython modules with no external library
deps, so they cost nothing to add: drop them from Setup.local's
*disabled* block (Unix) and add ClCompile entries to
MagPython.vcxproj (Windows). FEATURES.md is updated to reflect
the new module surface.

_curses needs ncurses, which is a new vendored dep — tracked
separately in #48.