### PR TITLE
Renovate: disable github-actions manager; Dependabot: weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,5 +4,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 6am on monday"],
+  "github-actions": {
+    "enabled": false
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
config:recommended enables Renovate's github-actions manager, which
overlaps with .github/dependabot.yaml's github-actions ecosystem.
Disable it on the Renovate side so Dependabot stays the source of
truth for action bumps, and bump Dependabot from monthly to weekly.