### PR TITLE
Add python and nasm to Renovate tracked deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,24 @@
       "depNameTemplate": "libffi",
       "packageNameTemplate": "libffi/libffi",
       "extractVersionTemplate": "^v(?<version>3\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^MagPython/python-version$"],
+      "matchStrings": ["^(?<currentValue>.+?)\\s*$"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "python",
+      "packageNameTemplate": "python/cpython",
+      "extractVersionTemplate": "^v(?<version>3\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^MagPython/nasm-version$"],
+      "matchStrings": ["^(?<currentValue>.+?)\\s*$"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "nasm",
+      "packageNameTemplate": "netwide-assembler/nasm",
+      "extractVersionTemplate": "^nasm-(?<version>2\\.\\d+\\.\\d+)$"
     }
   ],
   "postUpgradeTasks": {
@@ -45,14 +63,18 @@
       "MagPython/zlib-sha256",
       "MagPython/libffi-version",
       "MagPython/libffi-sha256",
-      "MagPython/libffi-msvc-include/ffi.h"
+      "MagPython/libffi-msvc-include/ffi.h",
+      "MagPython/python-version",
+      "MagPython/python-sha256",
+      "MagPython/nasm-version",
+      "MagPython/nasm-sha256"
     ],
     "executionMode": "update"
   },
   "packageRules": [
     {
       "matchManagers": ["custom.regex"],
-      "matchDepNames": ["openssl", "zlib", "libffi"],
+      "matchDepNames": ["openssl", "zlib", "libffi", "python", "nasm"],
       "commitMessageTopic": "{{depName}} pin",
       "commitMessageAction": "Bump",
       "groupName": null


### PR DESCRIPTION
Both have clean upstream GitHub tag conventions (v3.x.x for cpython, nasm-2.x.x for the netwide-assembler mirror), so Renovate can drive their pin bumps the same way it already does for openssl/zlib/libffi.

The corresponding update-python.sh and update-nasm.sh scripts already take a single positional <version> argument, so the existing postUpgradeTasks command template works unchanged; only the fileFilters list and the packageRules matchDepNames list needed extending.

https://claude.ai/code/session_01QCZPcDoosHmihrKrGZ3wBh