### PR TITLE
Drop the OpenSSL .sha256 sidecar cross-check

### DIFF
--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -272,9 +272,8 @@ setup_python() {
 # $BUILD so re-runs of the build script (which wipes $BUILD via
 # prep_build_tree) reuse the already-fetched tarball.
 #
-# madler/zlib doesn't publish per-tarball .sha256 sidecars on its
-# GitHub releases, so the expected hash is pinned in-tree at
-# MagPython/zlib-sha256 and checked against the downloaded bytes.
+# The expected hash is pinned in-tree at MagPython/zlib-sha256 and
+# checked against the downloaded bytes.
 setup_zlib() {
     if [ -d "$ZLIB_SRC" ]; then return 0; fi
 
@@ -317,8 +316,8 @@ setup_zlib() {
 # rename it to sqlite-<version> so the path consumers can refer to it
 # via SQLITE_SRC without recomputing the numeric encoding.
 #
-# sqlite.org doesn't publish per-zip .sha256 sidecars, so the expected
-# hash is pinned in-tree at MagPython/sqlite-sha256.
+# The expected hash is pinned in-tree at MagPython/sqlite-sha256 and
+# checked against the downloaded bytes.
 setup_sqlite() {
     if [ -d "$SQLITE_SRC" ]; then return 0; fi
 
@@ -367,9 +366,8 @@ EOF
 # Download + verify + extract the upstream libffi tarball into
 # $LIBFFI_CACHE/libffi-$LIBFFI_VERSION/. Idempotent.
 #
-# libffi/libffi doesn't publish per-tarball .sha256 sidecars on its
-# GitHub releases, so the expected hash is pinned in-tree at
-# MagPython/libffi-sha256 and checked against the downloaded bytes.
+# The expected hash is pinned in-tree at MagPython/libffi-sha256 and
+# checked against the downloaded bytes.
 setup_libffi() {
     if [ -d "$LIBFFI_SRC" ]; then return 0; fi
 
@@ -405,12 +403,8 @@ setup_libffi() {
 # lives outside $BUILD so re-runs of the build script (which wipes
 # $BUILD via prep_build_tree) reuse the already-fetched tarball.
 #
-# bytereef.org publishes hashes only in an HTML table on
-# https://www.bytereef.org/mpdecimal/download.html — there is no per-
-# tarball .sha256 sidecar to fetch. The expected hash is therefore
-# pinned in-tree at MagPython/libmpdec-sha256 and checked against the
-# downloaded bytes. A version bump means updating libmpdec-version AND
-# libmpdec-sha256 together (see README's "Updating pinned libmpdec").
+# The expected hash is pinned in-tree at MagPython/libmpdec-sha256 and
+# checked against the downloaded bytes.
 setup_libmpdec() {
     if [ -d "$LIBMPDEC_SRC" ]; then return 0; fi
 
@@ -613,11 +607,8 @@ openssl_shlib_version() {
 # outside $BUILD so re-runs of the build script (which wipes $BUILD via
 # prep_build_tree) reuse the already-fetched tarball.
 #
-# OpenSSL publishes per-tarball .sha256 sidecars on its GitHub Releases.
 # The expected hash is pinned in-tree at MagPython/openssl-sha256 and
-# checked against the downloaded bytes; the upstream sidecar is also
-# fetched and cross-checked as defense-in-depth (mirrors the Windows
-# download-openssl.ps1).
+# checked against the downloaded bytes.
 setup_openssl() {
     if [ -d "$OPENSSL_SRC" ]; then return 0; fi
 
@@ -625,14 +616,11 @@ setup_openssl() {
     mkdir -p "$OPENSSL_CACHE"
     local base="https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION"
     local tarball="$OPENSSL_CACHE/openssl-$OPENSSL_VERSION.tar.gz"
-    local sidecar="$tarball.sha256"
 
     if [ ! -f "$tarball" ]; then
         curl --fail --silent --show-error --location \
             -o "$tarball" "$base/openssl-$OPENSSL_VERSION.tar.gz"
     fi
-    curl --fail --silent --show-error --location \
-        -o "$sidecar" "$base/openssl-$OPENSSL_VERSION.tar.gz.sha256"
 
     local sha256_cmd
     if command -v shasum >/dev/null 2>&1; then sha256_cmd="shasum -a 256"
@@ -643,18 +631,11 @@ setup_openssl() {
     actual="$($sha256_cmd "$tarball" | awk '{print $1}')"
     if [ "$OPENSSL_SHA256" != "$actual" ]; then
         echo "OpenSSL SHA-256 mismatch: expected $OPENSSL_SHA256, got $actual" >&2
-        echo "  (pinned in MagPython/openssl-sha256 — confirm against $base/openssl-$OPENSSL_VERSION.tar.gz.sha256 before changing)" >&2
-        rm -f "$tarball" "$sidecar"
+        echo "  (pinned in MagPython/openssl-sha256 — regenerate via" >&2
+        echo "   MagPython/update-openssl.sh before changing)" >&2
+        rm -f "$tarball"
         exit 1
     fi
-    local upstream
-    upstream="$(awk '{print $1; exit}' "$sidecar")"
-    if [ "$OPENSSL_SHA256" != "$upstream" ]; then
-        echo "Upstream .sha256 sidecar disagrees with MagPython/openssl-sha256: sidecar=$upstream, pinned=$OPENSSL_SHA256" >&2
-        rm -f "$tarball" "$sidecar"
-        exit 1
-    fi
-    rm -f "$sidecar"
 
     tar -xzf "$tarball" -C "$OPENSSL_CACHE"
 }

--- a/MagPython/download-helpers.ps1
+++ b/MagPython/download-helpers.ps1
@@ -5,9 +5,9 @@
 # Why a separate file: the eight download-*.ps1 scripts (openssl,
 # zlib, libffi, sqlite, libmpdec, python, nasm, jom) each shipped
 # ~50-70 lines of nearly-identical boilerplate around 3 dep-specific
-# bits (URL, archive name, expected extract dir + optional rename /
-# sidecar cross-check). Concentrating the boilerplate here lets each
-# wrapper drop to ~12 lines of pure config.
+# bits (URL, archive name, expected extract dir + optional rename).
+# Concentrating the boilerplate here lets each wrapper drop to ~12
+# lines of pure config.
 #
 # Keep this file ASCII-only. Without a UTF-8 BOM, powershell.exe on
 # Windows reads .ps1 sources as Windows-1252; a UTF-8 em-dash (0xE2 0x80
@@ -58,10 +58,6 @@ $ErrorActionPreference = "Stop"
 #                     produced (relative to WorkDir). If set,
 #                     gets Move-Item'd to RenameTo.
 #   -RenameTo         optional. Companion to RenameFrom.
-#   -SidecarUrl       optional. URL of an upstream .sha256 sidecar
-#                     to fetch and cross-check against the pinned
-#                     hash, as defense-in-depth (catches a tampered
-#                     in-tree pin). Today only OpenSSL has one.
 #   -TarFlags         tar.exe flag string. Defaults to "-xzf" for
 #                     .tar.gz; pass "-xf" for .zip (tar.exe on
 #                     Windows 10+ uses libarchive and handles
@@ -78,7 +74,6 @@ function Get-PinnedSource {
         [string]$WorkDir = '',
         [string]$RenameFrom = '',
         [string]$RenameTo = '',
-        [string]$SidecarUrl = '',
         [string]$TarFlags = '-xzf'
     )
 
@@ -101,19 +96,6 @@ function Get-PinnedSource {
         if ($ExpectedSha256 -ne $actual) {
             Remove-Item -Force $ArchiveName
             throw "SHA-256 mismatch for ${ArchiveName}: expected $ExpectedSha256, got $actual (pinned in MagPython/$Name-sha256 -- regenerate via MagPython/update-$Name.sh before changing)"
-        }
-
-        if ($SidecarUrl -ne '') {
-            $sidecarName = "$ArchiveName.sha256"
-            Invoke-WebRequest -OutFile $sidecarName -Uri $SidecarUrl
-            # Sidecar format is "<hash> *<filename>" or just "<hash>";
-            # take the first whitespace-separated token, lowercased.
-            $sidecarHash = (((Get-Content $sidecarName -Raw).Trim().ToLower()) -split '\s+')[0]
-            if ($sidecarHash -ne $ExpectedSha256) {
-                Remove-Item -Force $ArchiveName, $sidecarName
-                throw "Upstream .sha256 sidecar disagrees with MagPython/$Name-sha256: sidecar=$sidecarHash, pinned=$ExpectedSha256"
-            }
-            Remove-Item -Force $sidecarName
         }
 
         & tar.exe $TarFlags $ArchiveName

--- a/MagPython/download-libffi.ps1
+++ b/MagPython/download-libffi.ps1
@@ -1,6 +1,4 @@
-# Download and unpack libffi. libffi/libffi doesn't publish per-tarball
-# .sha256 sidecars on its GitHub releases, so the in-tree pin is the
-# sole hash check.
+# Download and unpack libffi.
 #
 # This script does NOT regenerate the project-local
 # MagPython/libffi-msvc-include/ffi.h — that's update-libffi.sh's

--- a/MagPython/download-libmpdec.ps1
+++ b/MagPython/download-libmpdec.ps1
@@ -1,7 +1,4 @@
-# Download and unpack libmpdec (mpdecimal). bytereef.org doesn't publish
-# per-tarball .sha256 sidecars (the hashes live only in the HTML table at
-# https://www.bytereef.org/mpdecimal/download.html), so the in-tree pin
-# is the sole hash check.
+# Download and unpack libmpdec (mpdecimal).
 #
 # Keep this file ASCII-only (see download-helpers.ps1's note for why).
 $ErrorActionPreference = "Stop"

--- a/MagPython/download-nasm.ps1
+++ b/MagPython/download-nasm.ps1
@@ -1,5 +1,4 @@
-# Download and unpack netwide assembler. nasm.us doesn't publish
-# per-zip .sha256 sidecars, so the in-tree pin is the sole hash check.
+# Download and unpack netwide assembler.
 #
 # Stage the extracted tree as MagPython/nasm/ (unversioned) rather
 # than nasm-<version>/ so the openssl.vcxproj NMakeBuildCommandLine's

--- a/MagPython/download-openssl.ps1
+++ b/MagPython/download-openssl.ps1
@@ -1,7 +1,4 @@
-# Download and unpack OpenSSL. Verified against the pinned SHA-256
-# *and* the upstream .sha256 sidecar (defense-in-depth: the in-tree
-# pin defends against a tampered upstream tarball+sidecar pair, the
-# sidecar cross-check defends against a tampered in-tree pin).
+# Download and unpack OpenSSL. Verified against the pinned SHA-256.
 #
 # Keep this file ASCII-only (see download-helpers.ps1's note for why).
 $ErrorActionPreference = "Stop"
@@ -17,5 +14,4 @@ Get-PinnedSource `
     -Url "$BaseUrl/openssl-$Version.tar.gz" `
     -ArchiveName "openssl-$Version.tar.gz" `
     -TargetDir "openssl\openssl-$Version" `
-    -WorkDir 'openssl' `
-    -SidecarUrl "$BaseUrl/openssl-$Version.tar.gz.sha256"
+    -WorkDir 'openssl'

--- a/MagPython/download-zlib.ps1
+++ b/MagPython/download-zlib.ps1
@@ -1,6 +1,4 @@
-# Download and unpack zlib. madler/zlib doesn't publish per-tarball
-# .sha256 sidecars on its GitHub releases, so the in-tree pin is the
-# sole hash check.
+# Download and unpack zlib.
 #
 # Keep this file ASCII-only (see download-helpers.ps1's note for why).
 $ErrorActionPreference = "Stop"

--- a/MagPython/update-jom.sh
+++ b/MagPython/update-jom.sh
@@ -5,10 +5,8 @@
 # Usage: MagPython/update-jom.sh <version>
 #   e.g. MagPython/update-jom.sh 1.1.4
 #
-# qt.io's download page doesn't publish per-zip .sha256 sidecars on
-# the same path as the zip, so this script downloads the zip,
-# computes SHA-256 locally, and writes both pin files. jom is only
-# used on the Windows builder (it's a Windows-only nmake replacement).
+# jom is only used on the Windows builder (it's a Windows-only nmake
+# replacement).
 #
 # qt.io's URL uses underscore-separated version (jom_1_1_4.zip);
 # the substitution happens in update-pin-common.sh's update_pin

--- a/MagPython/update-libmpdec.sh
+++ b/MagPython/update-libmpdec.sh
@@ -5,12 +5,6 @@
 # Usage: MagPython/update-libmpdec.sh <version>
 #   e.g. MagPython/update-libmpdec.sh 2.5.2
 #
-# bytereef.org doesn't publish per-tarball .sha256 sidecars (the
-# hashes live only in the HTML table at
-# https://www.bytereef.org/mpdecimal/download.html), so this script
-# downloads the tarball and computes SHA-256 locally rather than
-# fetching a sidecar.
-#
 # Compatible with bash 3.2 (the default on macOS).
 
 set -eu

--- a/MagPython/update-nasm.sh
+++ b/MagPython/update-nasm.sh
@@ -5,12 +5,9 @@
 # Usage: MagPython/update-nasm.sh <version>
 #   e.g. MagPython/update-nasm.sh 2.16.03
 #
-# nasm.us doesn't publish per-zip .sha256 sidecars on its
-# releasebuilds tree, so this script downloads the win32 zip,
-# computes SHA-256 locally, and writes both pin files. Only the
-# Windows builder uses NASM (it's required by OpenSSL's x86 assembly);
-# Linux / macOS get nasm via the system package manager (or don't
-# need it at all because OpenSSL configures with the platform's
+# Only the Windows builder uses NASM (it's required by OpenSSL's x86
+# assembly); Linux / macOS get nasm via the system package manager (or
+# don't need it at all because OpenSSL configures with the platform's
 # default assembler).
 #
 # Compatible with bash 3.2 (the default on macOS).

--- a/MagPython/update-ncurses.sh
+++ b/MagPython/update-ncurses.sh
@@ -5,10 +5,9 @@
 # Usage: MagPython/update-ncurses.sh <version>
 #   e.g. MagPython/update-ncurses.sh 6.5
 #
-# invisible-island.net (the upstream) doesn't publish per-tarball
-# .sha256 sidecars in a Renovate-trackable form, so this script
-# downloads the tarball from ftp.gnu.org's GNU mirror, computes
-# SHA-256 locally, and writes both pin files.
+# Pulls from ftp.gnu.org's GNU mirror (the canonical upstream is
+# invisible-island.net, but ftp.gnu.org's layout is easier to fetch
+# programmatically).
 #
 # Compatible with bash 3.2 (the default on macOS).
 

--- a/MagPython/update-openssl.sh
+++ b/MagPython/update-openssl.sh
@@ -5,10 +5,6 @@
 # Usage: MagPython/update-openssl.sh <version>
 #   e.g. MagPython/update-openssl.sh 3.5.7
 #
-# The build downloads + verifies the tarball at build time, so this
-# script intentionally only fetches the small upstream .sha256 sidecar
-# rather than the full tarball.
-#
 # Compatible with bash 3.2 (the default on macOS).
 
 set -eu
@@ -20,5 +16,4 @@ update_pin \
     --version-pattern '3.[0-9]*.[0-9]*' \
     --version-pattern-help '3.x line' \
     --tarball-url 'https://github.com/openssl/openssl/releases/download/openssl-<v>/openssl-<v>.tar.gz' \
-    --sidecar-url 'https://github.com/openssl/openssl/releases/download/openssl-<v>/openssl-<v>.tar.gz.sha256' \
     "$@"

--- a/MagPython/update-pin-common.sh
+++ b/MagPython/update-pin-common.sh
@@ -14,7 +14,7 @@
 
 # update_pin: bump a dependency's version + SHA-256 pin files.
 #
-# Flags (all required except --sidecar-url):
+# Flags (all required):
 #   --name <dep>                e.g. "openssl"; pin files are
 #                                MagPython/<dep>-version /
 #                                MagPython/<dep>-sha256.
@@ -28,13 +28,6 @@
 #                                "3.x line", surfaced in error text.
 #   --tarball-url <tmpl>        URL template for the tarball; literal
 #                                "<v>" is replaced with the version.
-#   --sidecar-url <tmpl>        OPTIONAL. If set, fetch the upstream
-#                                .sha256 sidecar and use its hash.
-#                                If unset, download the tarball and
-#                                compute SHA-256 locally — the slow
-#                                path, used by deps whose upstreams
-#                                don't publish sidecars (libmpdec,
-#                                zlib, libffi, ...).
 #
 # Positional: <version>         the only positional arg.
 update_pin() {
@@ -42,7 +35,6 @@ update_pin() {
     local version_pattern=
     local version_pattern_help=
     local tarball_url_tmpl=
-    local sidecar_url_tmpl=
     local version=
 
     while [ "$#" -gt 0 ]; do
@@ -51,7 +43,6 @@ update_pin() {
             --version-pattern)       version_pattern="$2"; shift 2 ;;
             --version-pattern-help)  version_pattern_help="$2"; shift 2 ;;
             --tarball-url)           tarball_url_tmpl="$2"; shift 2 ;;
-            --sidecar-url)           sidecar_url_tmpl="$2"; shift 2 ;;
             -*)
                 echo "update_pin: unknown flag '$1'" >&2; return 64 ;;
             *)
@@ -93,16 +84,9 @@ update_pin() {
     local script_dir
     script_dir="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
 
-    local sha
-    if [ -n "$sidecar_url_tmpl" ]; then
-        local sidecar_url
-        sidecar_url="$(_update_pin_substitute "$sidecar_url_tmpl" "$version")"
-        sha="$(_update_pin_fetch_sidecar "$sidecar_url")" || return $?
-    else
-        local tarball_url
-        tarball_url="$(_update_pin_substitute "$tarball_url_tmpl" "$version")"
-        sha="$(_update_pin_download_and_hash "$tarball_url")" || return $?
-    fi
+    local sha tarball_url
+    tarball_url="$(_update_pin_substitute "$tarball_url_tmpl" "$version")"
+    sha="$(_update_pin_download_and_hash "$tarball_url")" || return $?
 
     # Validate: 64 lowercase hex chars exactly. A truncated download or
     # an HTML error page returned with a 200 (some upstreams) would
@@ -151,24 +135,6 @@ _update_pin_sha256_cmd() {
     elif command -v sha256sum >/dev/null 2>&1; then echo "sha256sum"
     else echo "Need shasum or sha256sum on PATH" >&2; return 1
     fi
-}
-
-_update_pin_fetch_sidecar() {
-    local url="$1"
-    echo "Fetching $url ..." >&2
-    local tmp
-    tmp="$(mktemp 2>/dev/null || mktemp -t pin-sidecar)"
-    if ! curl --fail --silent --show-error --location --output "$tmp" "$url"; then
-        echo "Failed to fetch the upstream .sha256 sidecar." >&2
-        rm -f "$tmp"
-        return 70
-    fi
-    # Sidecar format: "<hash> *<filename>" or just "<hash>"; first
-    # whitespace-separated token, lowercased.
-    local sha
-    sha="$(awk '{print tolower($1); exit}' "$tmp")"
-    rm -f "$tmp"
-    printf '%s' "$sha"
 }
 
 _update_pin_download_and_hash() {

--- a/MagPython/update-sqlite.sh
+++ b/MagPython/update-sqlite.sh
@@ -12,10 +12,6 @@
 # computed from the version's numeric encoding
 # (<major>*1000000 + <minor>*10000 + <patch>*100).
 #
-# sqlite.org doesn't publish per-zip .sha256 sidecars, so this script
-# downloads the zip, computes SHA-256 locally, and writes all three
-# pin files.
-#
 # Compatible with bash 3.2 (the default on macOS).
 
 set -eu

--- a/MagPython/update-zlib.sh
+++ b/MagPython/update-zlib.sh
@@ -5,10 +5,6 @@
 # Usage: MagPython/update-zlib.sh <version>
 #   e.g. MagPython/update-zlib.sh 1.3.2
 #
-# madler/zlib doesn't publish per-tarball .sha256 sidecars on its
-# GitHub releases, so this script downloads the tarball, computes
-# SHA-256 locally, and writes both pin files.
-#
 # Compatible with bash 3.2 (the default on macOS).
 
 set -eu

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ StopOnFirstFailure="True"`:
    `perl Configure VC-WIN32-ONECORE <no-* set>` and then
    `jom -j%NUMBER_OF_PROCESSORS% build_libs` inside the build-time-
    downloaded source tree (`MagPython/openssl/openssl-<v>/`, populated
-   by `download-openssl.ps1` and verified against the pinned SHA-256
-   *and* the upstream `.sha256` sidecar). `download-nasm.ps1` fetches
+   by `download-openssl.ps1` and verified against the pinned SHA-256).
+   `download-nasm.ps1` fetches
    NASM 2.16.01 from nasm.us before the build (NASM is required by
    OpenSSL's x86 assembly). `download-jom.ps1` fetches jom — Qt's
    drop-in `nmake` replacement that supports parallel jobs (`-j`);
@@ -295,23 +295,18 @@ lives in `MagPython/update-pin-common.sh`, and the wrappers refuse
 cross-major bumps so the build glue can be reviewed manually when an
 ABI line changes.
 
-OpenSSL is the only dep whose upstream publishes a `.sha256` sidecar
-the build can cross-check against the in-tree pin (and whose
-`update-openssl.sh` only needs to fetch that sidecar rather than the
-full tarball). For everyone else the in-tree pin is the sole hash
-check — upstreams either don't ship sidecars, or don't ship them in
-a Renovate-trackable form — so `update-<dep>.sh` downloads the
-tarball and computes SHA-256 locally.
+The in-tree pin is the sole hash check; `update-<dep>.sh` downloads
+the tarball and computes SHA-256 locally.
 
-| Dep      | Source                                 | Sidecar | Line | Bump command                   |
-| ---      | ---                                    | ---     | ---  | ---                            |
-| OpenSSL  | `openssl/openssl` GitHub Releases      | yes     | 3.x  | `update-openssl.sh 3.5.7`      |
-| zlib     | `madler/zlib` GitHub Releases          | no      | 1.x  | `update-zlib.sh 1.3.3`         |
-| SQLite   | sqlite.org                             | no      | 3.x  | `update-sqlite.sh 3.53.2 2025` |
-| libffi   | `libffi/libffi` GitHub Releases        | no      | 3.x  | `update-libffi.sh 3.5.3`       |
-| libmpdec | bytereef.org                           | no      | 2.x  | `update-libmpdec.sh 2.5.2`     |
-| ncurses  | ftp.gnu.org                            | no      | 6.x  | `update-ncurses.sh 6.5`        |
-| CPython  | `python/cpython` tag archive on GitHub | no      | 3.x  | `update-python.sh 3.13.14`     |
+| Dep      | Source                                 | Line | Bump command                   |
+| ---      | ---                                    | ---  | ---                            |
+| OpenSSL  | `openssl/openssl` GitHub Releases      | 3.x  | `update-openssl.sh 3.5.7`      |
+| zlib     | `madler/zlib` GitHub Releases          | 1.x  | `update-zlib.sh 1.3.3`         |
+| SQLite   | sqlite.org                             | 3.x  | `update-sqlite.sh 3.53.2 2025` |
+| libffi   | `libffi/libffi` GitHub Releases        | 3.x  | `update-libffi.sh 3.5.3`       |
+| libmpdec | bytereef.org                           | 2.x  | `update-libmpdec.sh 2.5.2`     |
+| ncurses  | ftp.gnu.org                            | 6.x  | `update-ncurses.sh 6.5`        |
+| CPython  | `python/cpython` tag archive on GitHub | 3.x  | `update-python.sh 3.13.14`     |
 
 libmpdec is the C library behind the `_decimal` module. ncurses is
 POSIX-only — the Windows artifact ships no curses module, so there is


### PR DESCRIPTION
## Summary

- OpenSSL's hash is already pinned in `MagPython/openssl-sha256`, so the upstream-sidecar fetch only defended against a tampered in-tree pin — a threat already covered by reviewing the pin diff at bump time, and one no other dep gets defense-in-depth against. Drop it.
- Removes the sidecar code paths from `update-pin-common.sh` (`--sidecar-url` flag, `_update_pin_fetch_sidecar`), `download-helpers.ps1` (`-SidecarUrl` parameter), and `setup_openssl` in `build-common.sh`. `update-openssl.sh` / `download-openssl.ps1` lose their sidecar args; `update-openssl.sh` now downloads + hashes locally like every other `update-<dep>.sh`.
- Strips the now-irrelevant "upstream X doesn't publish .sha256 sidecars" comments from the per-dep update / download / `setup_*` blocks and the sidecar paragraph + table column from `README.md`. `grep -in sidecar` over the repo is empty.

## Test plan

- [ ] `bash -n` each touched shell script (done locally)
- [ ] Windows CI: `download-openssl.ps1` still verifies against the pinned SHA-256 and extracts cleanly
- [ ] Linux + macOS CI: `setup_openssl` in `build-common.sh` still verifies against the pinned SHA-256
- [ ] Dry-run `MagPython/update-openssl.sh 3.6.2` rewrites the pin files to the same values that are committed today

https://claude.ai/code/session_012xRTLaAKQjTJtDgdYWRGpS

---
_Generated by [Claude Code](https://claude.ai/code/session_012xRTLaAKQjTJtDgdYWRGpS)_