### PR TITLE
Renovate: use loose versioning for NASM pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,7 +59,8 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "nasm",
       "packageNameTemplate": "netwide-assembler/nasm",
-      "extractVersionTemplate": "^nasm-(?<version>2\\.\\d+\\.\\d+)$"
+      "extractVersionTemplate": "^nasm-(?<version>2\\.\\d+\\.\\d+)$",
+      "versioningTemplate": "loose"
     }
   ],
   "postUpgradeTasks": {


### PR DESCRIPTION
The Dependency Dashboard (#52) lists every tracked dep with its current
version except MagPython/nasm-version, which appears with no detected
value. The reason is that 2.16.01 has a leading zero in the patch
component, which is not valid SemVer. Custom regex managers default to
semver-coerced versioning, which rejects/normalizes the value such that
it no longer matches the upstream tag derived via extractVersionTemplate
(nasm-2.16.01), so Renovate treats the dep as having no current version.

Switch this manager to loose versioning, which tolerates leading zeros
and lets Renovate recognize 2.16.01 as the current pin and offer 2.16.03
on the same line.