### PR TITLE
Add MagPython interpreter binary

### DIFF
--- a/.github/workflows/Verify python drift.yml
+++ b/.github/workflows/Verify python drift.yml
@@ -19,6 +19,7 @@ on:
       - 'MagPython/python-sha256'
       - 'MagPython/MagPython.vcxproj'
       - 'MagPython/FreezeMagPython.vcxproj'
+      - 'MagPython/MagPythonExe.vcxproj'
   workflow_dispatch:
 
 jobs:

--- a/MagPython/.gitignore
+++ b/MagPython/.gitignore
@@ -2,5 +2,6 @@
 /Release
 /Release-Int*
 /Release-test
+/Release-MagPythonExe
 /nasm
 /nasm.zip

--- a/MagPython/MagPython.metaproj
+++ b/MagPython/MagPython.metaproj
@@ -13,6 +13,7 @@
         <ProjectLibMpdec Include="$(SolutionDir)\LibMpdec.vcxproj" />
         <ProjectFreezeMagPython Include="$(SolutionDir)\FreezeMagPython.vcxproj" />
         <ProjectMagPython Include="$(SolutionDir)\MagPython.vcxproj" />
+        <ProjectMagPythonExe Include="$(SolutionDir)\MagPythonExe.vcxproj" />
         <ProjectTest Include="$(SolutionDir)\test.vcxproj" />
     </ItemGroup>
 
@@ -57,6 +58,12 @@
                 BuildInParallel="True" StopOnFirstFailure="True"
                 Properties="SolutionDir=$(SolutionDir);Configuration=$(Configuration);Platform=$(Platform)"
                 Projects="@(ProjectMagPython)">
+            <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+        </MSBuild>
+        <MSBuild
+                BuildInParallel="True" StopOnFirstFailure="True"
+                Properties="SolutionDir=$(SolutionDir);Configuration=$(Configuration);Platform=$(Platform)"
+                Projects="@(ProjectMagPythonExe)">
             <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
         </MSBuild>
         <MSBuild

--- a/MagPython/MagPythonExe.vcxproj
+++ b/MagPython/MagPythonExe.vcxproj
@@ -107,4 +107,13 @@
   <Target Name="RunVersion" AfterTargets="Build">
     <Exec Command="&quot;$(OutDir)MagPython.exe&quot; --version" UseCommandProcessor="false" ContinueOnError="false" />
   </Target>
+
+  <!-- Stage a python3.exe alias alongside MagPython.exe so consumers
+       expecting the canonical CPython binary name find one in the
+       artifact. Plain Copy rather than a symlink because the Windows
+       artifact is zipped and unzipped by tools that don't preserve
+       NTFS junctions / symlinks reliably. -->
+  <Target Name="CopyAsPython3" AfterTargets="RunVersion">
+    <Copy SourceFiles="$(OutDir)MagPython.exe" DestinationFiles="$(OutDir)python3.exe" />
+  </Target>
 </Project>

--- a/MagPython/MagPythonExe.vcxproj
+++ b/MagPython/MagPythonExe.vcxproj
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MagPython.exe — the python3.exe equivalent for the MagPython artifact.
+
+  Tiny console program (CPython upstream's Programs/python.c) that calls
+  Py_Main, linked dynamically against MagPython.dll via the
+  #pragma comment(lib, "MagPython.lib") rewritten into pyconfig.h by
+  magpython-pyconfig-h.targets. Builds AFTER MagPython.vcxproj so the
+  staged headers + import lib in $(MSBuildProjectDirectory)\$(Configuration)
+  are present, and emits MagPython.exe into the same Release directory so
+  the artifact zip picks it up next to MagPython.dll.
+
+  Modelled on test.vcxproj — same shape, different source file, output
+  goes into the shared Release dir rather than a private subdir.
+-->
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1C9B5AA8-7F4F-4D0C-A0AB-7E2D8B9D1A11}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>MagPythonExe</RootNamespace>
+    <ProjectName>MagPythonExe</ProjectName>
+  </PropertyGroup>
+  <Import Project="common.props" />
+  <PropertyGroup>
+    <PythonSourceDir>$(MSBuildProjectDirectory)\python\python-$(PythonVersion)\</PythonSourceDir>
+    <IntDir>$(MSBuildProjectDirectory)\$(Configuration)-MagPythonExe\</IntDir>
+    <!-- Share OutDir with MagPython.vcxproj so MagPython.exe lands next
+         to MagPython.dll and is picked up by the artifact zip without
+         a separate copy step. Same pattern the dep Makefile-type
+         projects use (their CopyArtifacts targets stage into this dir
+         too). The intermediate dir above stays private so MSBuild's
+         per-project tracking doesn't see the .dll's outputs. -->
+    <OutDir>$(MSBuildProjectDirectory)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup>
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup>
+    <TargetName>MagPython</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- Pull in the staged headers next to MagPython.dll (Python.h +
+           the pragma-patched pyconfig.h that auto-links MagPython.lib).
+           Programs/python.c does `#include "Python.h"`, so the Python
+           subdir needs to be on the include path directly. -->
+      <AdditionalIncludeDirectories>$(OutDir)\Include\Python</AdditionalIncludeDirectories>
+      <CompileAsManaged>false</CompileAsManaged>
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <OmitFramePointers>true</OmitFramePointers>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <!-- MagPython.lib (the import lib for MagPython.dll) is dropped
+           into $(OutDir) by MagPython.vcxproj's link step. The pragma
+           in pyconfig.h auto-references MagPython.lib by name, so we
+           only need to put $(OutDir) on the search path. -->
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="$(PythonSourceDir)\Programs\python.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+
+  <!-- Smoke-test the built MagPython.exe by invoking it with the
+       version flag. The full artifact (MagPython.dll, stdlib, OpenSSL
+       DLLs) is already in $(OutDir), so the exe runs in place. A
+       failure here fails the build (same shape as test.vcxproj's
+       RunTest). -->
+  <Target Name="RunVersion" AfterTargets="Build">
+    <Exec Command="&quot;$(OutDir)MagPython.exe&quot; --version" UseCommandProcessor="false" ContinueOnError="false" />
+  </Target>
+</Project>

--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -924,6 +924,27 @@ verify_no_static_dep_leakage() {
     fi
 }
 
+# Build the MagPython executable (CPython's Programs/python.c — a tiny
+# wrapper around Py_BytesMain) and stage it next to libMagPython in the
+# artifact tree. Counterpart to MagPython.exe on Windows
+# (MagPythonExe.vcxproj). Dynamically linked against libMagPython.so/.dylib
+# via -lMagPython; rpath '$ORIGIN' / '@loader_path' so the binary finds
+# its sibling lib + lib/python<X.Y>/ stdlib without env vars when invoked
+# from inside the artifact dir.
+# $1: rpath token ('$ORIGIN' on Linux, '@loader_path' on macOS).
+build_magpython_exe() {
+    local rpath_token="$1"
+    log "Building MagPython executable"
+    cc "$PYTHON_SRC/Programs/python.c" \
+        -I"$STAGE/include/Python" \
+        -L"$STAGE" \
+        "-Wl,-rpath,${rpath_token}" \
+        -lMagPython \
+        -o "$STAGE/MagPython"
+    log "Smoke-testing MagPython --version"
+    (cd "$STAGE" && ./MagPython --version)
+}
+
 # Build and run the smoke test (MagPython/test.c) against the staged tree.
 # $1: rpath token ('$ORIGIN' on Linux, '@loader_path' on macOS).
 # $2..: extra link args (e.g. '-ldl' on Linux for dladdr; macOS has it

--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -931,6 +931,12 @@ verify_no_static_dep_leakage() {
 # via -lMagPython; rpath '$ORIGIN' / '@loader_path' so the binary finds
 # its sibling lib + lib/python<X.Y>/ stdlib without env vars when invoked
 # from inside the artifact dir.
+#
+# Also stages a `python3` copy next to it so consumers expecting the
+# canonical CPython binary name find one in the artifact. Same shape
+# upstream uses (python3 alongside python3.<minor> on Linux/macOS); a
+# copy rather than a symlink keeps `zip` happy across all three
+# platforms (Windows artifact does the same — see MagPythonExe.vcxproj).
 # $1: rpath token ('$ORIGIN' on Linux, '@loader_path' on macOS).
 build_magpython_exe() {
     local rpath_token="$1"
@@ -943,6 +949,8 @@ build_magpython_exe() {
         -o "$STAGE/MagPython"
     log "Smoke-testing MagPython --version"
     (cd "$STAGE" && ./MagPython --version)
+    log "Staging python3 alias next to MagPython"
+    cp "$STAGE/MagPython" "$STAGE/python3"
 }
 
 # Build and run the smoke test (MagPython/test.c) against the staged tree.

--- a/MagPython/build-linux.sh
+++ b/MagPython/build-linux.sh
@@ -125,5 +125,6 @@ stage_openssl_headers
 stage_licenses
 verify_no_static_dep_leakage "$STAGE/libMagPython.so"
 run_smoke_test '$ORIGIN' -ldl
+build_magpython_exe '$ORIGIN'
 
 zip_artifact linux-x86_64

--- a/MagPython/build-macos.sh
+++ b/MagPython/build-macos.sh
@@ -169,6 +169,7 @@ stage_openssl_headers
 stage_licenses
 verify_no_static_dep_leakage "$STAGE/libMagPython.dylib"
 run_smoke_test '@loader_path'
+build_magpython_exe '@loader_path'
 
 # Sanity: only @rpath/* and system libs should remain in the LC_LOAD_DYLIB
 # entries of any shipped dylib. libssl in particular must not retain the

--- a/MagPython/check-python-drift.sh
+++ b/MagPython/check-python-drift.sh
@@ -35,7 +35,7 @@ fi
 
 missing_total=0
 ref_total=0
-for vcxproj in "$SCRIPT_DIR/MagPython.vcxproj" "$SCRIPT_DIR/FreezeMagPython.vcxproj"; do
+for vcxproj in "$SCRIPT_DIR/MagPython.vcxproj" "$SCRIPT_DIR/FreezeMagPython.vcxproj" "$SCRIPT_DIR/MagPythonExe.vcxproj"; do
     [ -f "$vcxproj" ] || { echo "ERROR: missing $vcxproj" >&2; exit 1; }
 
     # Pull each Include="$(PythonSourceDir)\..." path that ends in .c or .h.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ suffix to the DLLs):
 MagPython/
   MagPython.dll                       # Python core + builtin modules + zlib + sqlite + libffi + libmpdec
   MagPython.exe                       # python3.exe equivalent — Py_Main wrapper linked against MagPython.dll
+  python3.exe                         # copy of MagPython.exe under the canonical CPython binary name
   libcrypto-3.dll / libcrypto-3-x64.dll   # OpenSSL (x86 / x64)
   libssl-3.dll    / libssl-3-x64.dll      # OpenSSL (x86 / x64)
   include/Python/...                  # Public + cpython + internal headers, plus PC/pyconfig.h
@@ -37,6 +38,7 @@ Linux (`MagPython-linux-x86_64.zip`):
 MagPython/
   libMagPython.so        # SONAME libMagPython.so, RUNPATH $ORIGIN
   MagPython              # python3 equivalent — Py_BytesMain wrapper, RUNPATH $ORIGIN
+  python3                # copy of MagPython under the canonical CPython binary name
   libcrypto.so.3
   libssl.so.3
   libsqlite3.so.0        # SONAME libsqlite3.so.0
@@ -53,6 +55,7 @@ macOS arm64 (`MagPython-macos-arm64.zip`):
 MagPython/
   libMagPython.dylib     # install_name @rpath/libMagPython.dylib
   MagPython              # python3 equivalent — Py_BytesMain wrapper, LC_RPATH @loader_path
+  python3                # copy of MagPython under the canonical CPython binary name
   libcrypto.3.dylib      # install_name @rpath/libcrypto.3.dylib
   libssl.3.dylib         # install_name @rpath/libssl.3.dylib
   libsqlite3.0.dylib     # install_name @rpath/libsqlite3.0.dylib

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ suffix to the DLLs):
 ```
 MagPython/
   MagPython.dll                       # Python core + builtin modules + zlib + sqlite + libffi + libmpdec
+  MagPython.exe                       # python3.exe equivalent — Py_Main wrapper linked against MagPython.dll
   libcrypto-3.dll / libcrypto-3-x64.dll   # OpenSSL (x86 / x64)
   libssl-3.dll    / libssl-3-x64.dll      # OpenSSL (x86 / x64)
   include/Python/...                  # Public + cpython + internal headers, plus PC/pyconfig.h
@@ -35,6 +36,7 @@ Linux (`MagPython-linux-x86_64.zip`):
 ```
 MagPython/
   libMagPython.so        # SONAME libMagPython.so, RUNPATH $ORIGIN
+  MagPython              # python3 equivalent — Py_BytesMain wrapper, RUNPATH $ORIGIN
   libcrypto.so.3
   libssl.so.3
   libsqlite3.so.0        # SONAME libsqlite3.so.0
@@ -50,6 +52,7 @@ macOS arm64 (`MagPython-macos-arm64.zip`):
 ```
 MagPython/
   libMagPython.dylib     # install_name @rpath/libMagPython.dylib
+  MagPython              # python3 equivalent — Py_BytesMain wrapper, LC_RPATH @loader_path
   libcrypto.3.dylib      # install_name @rpath/libcrypto.3.dylib
   libssl.3.dylib         # install_name @rpath/libssl.3.dylib
   libsqlite3.0.dylib     # install_name @rpath/libsqlite3.0.dylib
@@ -58,6 +61,14 @@ MagPython/
   lib/python3.13/
   lib/python3.13/lib-dynload/
 ```
+
+The `MagPython` / `MagPython.exe` binary is upstream's `Programs/python.c`
+compiled against the shipped headers and dynamically linked against
+`libMagPython.{so,dylib,dll}`. The artifact is laid out so the binary's
+path discovery finds the bundled stdlib without env vars:
+`PATH`/`@loader_path`/`$ORIGIN` resolves the lib next door, and Python's
+`os.py` lookup walks up to `lib/python<X.Y>/os.py` in the same artifact
+directory.
 
 Notable differences from a stock CPython Windows build:
 
@@ -157,7 +168,13 @@ StopOnFirstFailure="True"`:
    target then stages headers and the pure-Python stdlib into
    `Release/include/Python/` and `Release/lib/` so the output directory
    is a complete SDK drop.
-8. **`test.vcxproj`** — compiles `MagPython/test.c` (a tiny embedding host
+8. **`MagPythonExe.vcxproj`** — compiles CPython's `Programs/python.c`
+   (the tiny `wmain` / `Py_Main` wrapper that ships as `python3.exe`
+   upstream) and emits `MagPython.exe` into `Release/`, dynamically
+   linked against `MagPython.dll` via the `#pragma comment(lib,
+   "MagPython.lib")` in the project-patched `pyconfig.h`. A
+   post-build `<Exec>` runs `MagPython.exe --version` as a smoke test.
+9. **`test.vcxproj`** — compiles `MagPython/test.c` (a tiny embedding host
    that calls `Py_Initialize`, prints the compiler string, and runs an
    `import sys` line), copies the DLLs and `lib/` next to it, and **executes
    `test.exe`** as part of the build via an `<Exec>` task. A failed smoke
@@ -247,7 +264,11 @@ shape as the Windows metaproj:
    libs (with a `Python/python.h -> Python.h` symlink so
    `MagPython/test.c`'s lowercase include resolves on case-sensitive
    filesystems), `MagPython/test.c` is built and run against the staged
-   tree (failure fails the build), and the final zip is produced.
+   tree (failure fails the build), the `MagPython` interpreter binary
+   (CPython's `Programs/python.c`, dynamically linked against
+   `libMagPython.{so,dylib}` with `$ORIGIN` / `@loader_path` rpath) is
+   compiled into `$STAGE/` and smoke-tested with `--version`, and the
+   final zip is produced.
 
 The host Python required by `regen-frozen` is
 `/opt/python/cp313-cp313/bin/python3` inside the manylinux_2_28 container


### PR DESCRIPTION
## Summary

The build currently ships `MagPython.dll` / `libMagPython.{so,dylib}` but no
counterpart to upstream's `python3.exe` / `python3` binary, so consumers can't
launch the interpreter directly out of the artifact. This PR adds that binary
on all three platforms, dynamically linked against the existing shared lib
(not statically). On each platform a `python3` / `python3.exe` copy is staged
alongside under the canonical CPython binary name.

- **Windows**: new `MagPythonExe.vcxproj` compiles upstream `Programs/python.c`
  into `MagPython.exe` and emits it into the shared `Release\` output dir.
  Auto-links via the `#pragma comment(lib, "MagPython.lib")` already baked
  into the project-patched `pyconfig.h`, so no extra link plumbing. Slotted
  into `MagPython.metaproj` after `MagPython.vcxproj` and before
  `test.vcxproj`. Post-build targets run `MagPython.exe --version` as a
  smoke test, then copy to `python3.exe`.
- **POSIX**: new `build_magpython_exe` helper in `build-common.sh` `cc`s
  `Programs/python.c` against the staged `libMagPython.{so,dylib}` with the
  same `$ORIGIN` / `@loader_path` rpath the lib already uses, runs
  `--version`, and copies to `python3`. Called from both `build-linux.sh`
  and `build-macos.sh` after the existing `MagPython/test.c` smoke test.

The `check-python-drift.sh` script and `Verify python drift.yml` workflow
are extended to scan the new vcxproj for `$(PythonSourceDir)` refs alongside
the existing two, so a cross-minor CPython bump that renames `Programs/python.c`
upstream gets caught at PR-review time.

Artifact additions (per platform):

```
Windows: MagPython.exe + python3.exe (next to MagPython.dll)
Linux:   MagPython     + python3      (next to libMagPython.so)
macOS:   MagPython     + python3      (next to libMagPython.dylib)
```

## Test plan

- [ ] Windows x86 CI: `MagPython.exe --version` runs from `Release\`,
      `python3.exe` exists in the zip
- [ ] Windows x64 CI: same as above
- [ ] Linux CI: `MagPython --version` exits 0 mid-build, `python3` shipped
- [ ] macOS CI: same as Linux
- [ ] All four artifact zips contain both binaries next to the shared lib
- [ ] `Verify python drift.yml` still passes on the existing pinned CPython
- [ ] Manually verify post-extract: `cd MagPython && ./MagPython -c "import ssl, sqlite3, _decimal; print('ok')"`

Sandbox note: I couldn't run the full Linux build end-to-end here because
the sandbox blocks downloads from `sqlite.org` and `ftp.gnu.org` (the
upstream sources for the SQLite amalgamation and ncurses tarball). The
build reached the libffi step cleanly; the python.c → libpython link path
itself was verified independently against the system libpython3.13.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEZBDciLQ95xUCpRQ3g44Y)_