### PR TITLE
Embed Windows manifest, ship _sysconfigdata in artifact

### DIFF
--- a/MagPython/MagPythonExe.vcxproj
+++ b/MagPython/MagPythonExe.vcxproj
@@ -95,6 +95,13 @@
            the .rc file's own directory (PC/), so python.manifest +
            icons/python.ico get picked up automatically. -->
       <AdditionalIncludeDirectories>$(PythonSourceDir)\PC;$(PythonSourceDir)\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <!-- python_ver_rc.h's PYVERSION64 macro references FIELD3, which
+           upstream's pyproject.props normally injects as a preprocessor
+           define computed from patchlevel.h. Without it the resource
+           compiler fails with RC2104 ("undefined keyword or key name:
+           FIELD3"). $(PythonField3Value) is computed in common.props
+           from the pinned PythonVersion. -->
+      <PreprocessorDefinitions>FIELD3=$(PythonField3Value);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/MagPython/MagPythonExe.vcxproj
+++ b/MagPython/MagPythonExe.vcxproj
@@ -59,6 +59,14 @@
   </ImportGroup>
   <PropertyGroup>
     <TargetName>MagPython</TargetName>
+    <!-- Disable MSBuild's auto-generated assembly manifest so the
+         RT_MANIFEST embedded by python_exe.rc (which references
+         PC/python.manifest) is the one that ends up in the PE
+         resource section. Without this, MSBuild generates a default
+         no-supportedOS manifest and the resource compiler's manifest
+         conflicts with it. Same effect as upstream's python.vcxproj,
+         which inherits this from pyproject.props. -->
+    <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -80,6 +88,14 @@
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <OmitFramePointers>true</OmitFramePointers>
     </ClCompile>
+    <ResourceCompile>
+      <!-- python_exe.rc #includes python_ver_rc.h, which #includes
+           modsupport.h / patchlevel.h from Include/. The RT_MANIFEST
+           and ICON paths in python_exe.rc are resolved relative to
+           the .rc file's own directory (PC/), so python.manifest +
+           icons/python.ico get picked up automatically. -->
+      <AdditionalIncludeDirectories>$(PythonSourceDir)\PC;$(PythonSourceDir)\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -94,6 +110,15 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="$(PythonSourceDir)\Programs\python.c" />
+    <!-- Embed CPython's standard EXE resource: version info + icon +
+         RT_MANIFEST pointing at PC/python.manifest. The manifest
+         declares supportedOS GUIDs for Windows 7/8/8.1/10/11 plus
+         longPathAware=true, so GetVersionExW reports the actual OS
+         version (rather than lying with Windows 8.1's build 9600
+         under app-compat). Without it, _pyrepl/main.py rejects the
+         platform with "Windows 10 TH2 or later required" the first
+         time a user drops into the REPL. -->
+    <ResourceCompile Include="$(PythonSourceDir)\PC\python_exe.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MagPython/build-common.sh
+++ b/MagPython/build-common.sh
@@ -869,6 +869,22 @@ stage_headers_and_stdlib() {
     # on rsync (manylinux_2_28 doesn't ship it) or GNU-specific cp --parents.
     (cd "$PYTHON_SRC/Lib" && find . -name '*.py' -print0 | tar --null -T - -cf -) \
         | (cd "$STAGE/lib/python$PY_X_Y" && tar -xf -)
+    # Pull in the build-generated _sysconfigdata_<abi>_<plat>_<multi>.py.
+    # sysconfig._init_posix imports it by name (see Lib/sysconfig/__init__.py
+    # _get_sysconfigdata_name); upstream's `make install` would copy it
+    # alongside the rest of the stdlib, but we don't run install — only
+    # make. Without it, anything that asks sysconfig for config vars
+    # (e.g. `help()` → pydoc → sysconfig.get_path) raises
+    # ModuleNotFoundError on first use. The `pybuilddir.txt` Makefile
+    # target writes the file under build/lib.<platform>-cpython-X.Y/;
+    # exactly one such .py per build.
+    local sysconfigdata_file
+    sysconfigdata_file="$(find "$build_dir/build" -maxdepth 2 -type f -name '_sysconfigdata_*.py' -print -quit 2>/dev/null || true)"
+    if [ -z "$sysconfigdata_file" ]; then
+        echo "stage_headers_and_stdlib: could not find generated _sysconfigdata_*.py under $build_dir/build/" >&2
+        exit 1
+    fi
+    cp "$sysconfigdata_file" "$STAGE/lib/python$PY_X_Y/"
 }
 
 # Verify $1 (the libMagPython artifact) has no dynamic linkage to any of

--- a/MagPython/common.props
+++ b/MagPython/common.props
@@ -51,5 +51,20 @@
 
     <_PythonVersionRaw>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)python-version'))</_PythonVersionRaw>
     <PythonVersion>$(_PythonVersionRaw.Trim())</PythonVersion>
+    <!--
+      FIELD3 is upstream's stand-in for the patch-level number embedded in
+      the Windows VERSIONINFO resource (PC/python_ver_rc.h's
+      PYVERSION64 = MAJOR, MINOR, FIELD3, PYTHON_API_VERSION). Upstream's
+      PCbuild/python.props parses Include/patchlevel.h to compute it as
+      `micro * 1000 + ReleaseLevelNumber * 10 + serial`. We always pin to
+      stable releases (update-python.sh enforces same-major bumps and
+      CPython only does pre-releases for X.Y.0), so ReleaseLevelNumber is
+      always 15 (final) and serial 0 — derive FIELD3 directly from the
+      pinned version's micro component. Consumed by MagPythonExe.vcxproj
+      as a ResourceCompile preprocessor define when building the
+      MagPython.exe version-info / manifest resources.
+    -->
+    <PythonMicroVersion>$([System.Text.RegularExpressions.Regex]::Match('$(PythonVersion)', '^\d+\.\d+\.(\d+)').Groups[1].Value)</PythonMicroVersion>
+    <PythonField3Value>$([MSBuild]::Add($([MSBuild]::Multiply($(PythonMicroVersion), 1000)), 150))</PythonField3Value>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Two follow-ups to PR #69, both consumer-facing bugs that only surface at
runtime in the shipped artifact.

## 1. Windows manifest on MagPython.exe

**Symptom.** Dropping into the REPL from `MagPython.exe` (or `python3.exe`)
prints to stderr:

```
warning: can't use pyrepl: Windows 10 TH2 or later required
```

**Cause.** `Lib/_pyrepl/main.py:9` checks `sys.getwindowsversion().build < 10586`.
That value comes from `GetVersionExW`, which on modern Windows enforces
*application manifest compatibility*: without a manifest declaring
`supportedOS` for Windows 10/11, the OS lies and reports Windows 8.1
(build 9600). The fresh `MagPython.exe` had no manifest at all.

**Fix.** Add `PC/python_exe.rc` as a `<ResourceCompile>` in
`MagPythonExe.vcxproj`. That `.rc` already references `PC/python.manifest`,
which declares supportedOS GUIDs for Win 7/8/8.1/10/11 plus
`longPathAware=true`. `<GenerateManifest>false</GenerateManifest>`
suppresses MSBuild's default no-supportedOS manifest so the
`.rc`-embedded one wins (same setup upstream's `python.vcxproj` inherits
from `pyproject.props`). Resource compiler also gets `$(PythonSourceDir)\Include`
on its include path so `python_ver_rc.h`'s indirect `modsupport.h` /
`patchlevel.h` includes resolve.

x86 and x64 both gain the manifest from the same project.

## 2. `_sysconfigdata_<abi>_<plat>_<multi>` missing from POSIX artifact

**Symptom (reported on macOS arm64, identical on Linux).** First call into
sysconfig raises `ModuleNotFoundError`. Repro:

```python
$ ./MagPython
Python 3.13.13 (main, May 14 2026, 16:45:44) [Clang 15.0.0] on darwin
>>> help()
... pydoc.py:529, in <module> class Doc:
... sysconfig/__init__.py:361, in _init_posix
...     _temp = __import__(name, ...)
ModuleNotFoundError: No module named '_sysconfigdata__darwin_darwin'
```

**Cause.** `Lib/sysconfig/__init__.py` imports
`_sysconfigdata_<sys.abiflags>_<sys.platform>_<sys.implementation._multiarch>`
to get build-time vars. CPython generates it under
`$builddir/build/lib.<platform>-<version>/_sysconfigdata_*.py` via
`Makefile.pre.in`'s `pybuilddir.txt` target, then `make install` would
copy it into `$LIBDEST`. Our build runs `make` but not `make install`,
and `stage_headers_and_stdlib` was only globbing `.py` files from
`$PYTHON_SRC/Lib/` (upstream source tree).

**Fix.** Pull the build-generated `_sysconfigdata_*.py` into
`$STAGE/lib/python$PY_X_Y/`. Hard-fail the build if it's not found
rather than ship a quietly-broken artifact.

Windows is not affected — `_init_nt` doesn't import `_sysconfigdata`.

## Test plan

- [ ] Windows x86 / x64 CI: `dumpbin /manifest MagPython.exe` shows the
      `supportedOS` GUIDs for Win 7..11; CI build still green
- [ ] After downloading the windows-x64 zip: `MagPython.exe` interactive,
      no `pyrepl` warning; `>>> import sys; sys.getwindowsversion().build`
      reports the real OS build (not 9600)
- [ ] Linux / macOS CI: artifact zip contains
      `MagPython/lib/python3.13/_sysconfigdata_*.py` (exactly one file)
- [ ] After downloading the macos-arm64 / linux-x86_64 zip:
      `./MagPython -c "import sysconfig; print(sysconfig.get_paths())"`
      exits 0; `./MagPython -c "help"` interactive `help()` doesn't crash
- [ ] `Verify python drift.yml` still passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEZBDciLQ95xUCpRQ3g44Y)_