### PR TITLE
Update GitHub Actions runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/Build All.yml
+++ b/.github/workflows/Build All.yml
@@ -44,7 +44,7 @@ jobs:
             msvc-arch: x64
             msbuild-platform: x64
           - platform: linux-x86_64
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             container: quay.io/pypa/manylinux_2_28_x86_64
           - platform: macos-arm64
             runs-on: macos-14

--- a/.github/workflows/Verify libffi drift.yml
+++ b/.github/workflows/Verify libffi drift.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   drift:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/Verify python drift.yml
+++ b/.github/workflows/Verify python drift.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   drift:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
This pull request updates the GitHub Actions workflow runners to use Ubuntu 24.04 instead of Ubuntu 22.04 and ubuntu-latest across multiple CI workflows.

## Key Changes
- **Build All workflow**: Updated linux-x86_64 runner from `ubuntu-22.04` to `ubuntu-24.04`
- **Verify libffi drift workflow**: Updated runner from `ubuntu-latest` to `ubuntu-24.04`
- **Verify python drift workflow**: Updated runner from `ubuntu-latest` to `ubuntu-24.04`

## Details
These changes ensure consistent use of Ubuntu 24.04 LTS across all Linux-based CI jobs, replacing both the pinned 22.04 version and the floating `ubuntu-latest` tag. This provides more predictable and up-to-date build environments while maintaining stability through the use of a specific LTS release rather than a floating tag.

https://claude.ai/code/session_01LJbmrL1Z9iZ5VG7xNbsRFL